### PR TITLE
Introduce pytest fixtures into tests (TIK-63)

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,5 +1,4 @@
 """Tests for core modules."""
-import os
 import glob
 import pytest
 import platform
@@ -94,10 +93,11 @@ def test_io(tmp_path):
         _io.read(file_path=str(tmp_path/"test_io.NA"))
 
     # create the non existing folder
+    # FIXME(ckutlu): folder_check really shouldn't be doing this.
     _io.folder_check(str(tmp_path / "test_io_folder" / "test_io.json"))
 
     # delete the folder with os.rmdir
-    os.rmdir(str(tmp_path / "test_io_folder"))
+    (tmp_path / "test_io_folder").rmdir()
 
     # corrupt the test_io.json file purpose is to test the file_exists function
     with open(tmp_path / "test_io.json", "w") as f:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -10,14 +10,14 @@ from tik_manager4.core import io
 from tik_manager4.external.filelock import FileLock, Timeout
 
 
-def test_filelog():
+def test_filelog(tmp_path: Path):
     """Test filelog module."""
+    tmp_path_ = str(tmp_path)  # FIXME: remove when FileLog is typed
     # test new log
-    _test_log_dir =os.path.expanduser("~")
-    # if the log file exists, delete it
-    if os.path.exists(os.path.join(_test_log_dir, "test_log.log")):
-        os.remove(os.path.join(_test_log_dir, "test_log.log"))
-    log = filelog.Filelog(logname=__name__, filename="test_log")
+    logbasename = "test_log"
+    
+    test_log_path = tmp_path / f"{logbasename}.log"
+    log = filelog.Filelog(logname=__name__, filename=f"{logbasename}", filedir=tmp_path_)
 
     assert log.header("Header Test") == "Header Test"
     assert log.title("Title Test") == "Title Test"
@@ -29,12 +29,12 @@ def test_filelog():
     assert log.get_last_message() == ("do_not_proceed", "error")
 
     # test continuing from existing log
-    log = filelog.Filelog(logname="new_log_name", filename="test_log", file_dir=_test_log_dir, date=False, time=False, size_cap=0)
+    log = filelog.Filelog(logname="new_log_name", filename="test_log", filedir=tmp_path_, date=False, time=False, size_cap=0)
     assert log._get_now() == ""
     assert log.title("Test") == "Test"
     log.clear()
     
-    with open(Path(_test_log_dir) / 'test_log.log') as fin:
+    with open(tmp_path / 'test_log.log') as fin:
         log_file_contents = fin.read()
 
     log_file_contents_truth = "============\nnew_log_name\n============\n\n"
@@ -51,34 +51,27 @@ def test_filelog():
     assert log.get_size() == nbytes_truth_per_system[platform.system()]
 
 
-def test_io():
+def test_io(tmp_path):
     """Test io module"""
-    test_io_files = glob.glob(os.path.join(os.path.expanduser("~"), "test_io.*"))
-    # if there are any, delete them
-    if test_io_files:
-        for test_io_file in test_io_files:
-            os.remove(test_io_file)
-
     # create a io module without any arguments
     _io = io.IO()
     # try defining non-valid file type
     with pytest.raises(Exception):
-        _io.file_path = os.path.join(os.path.expanduser("~"), "test_io.NA")
+        _io.file_path = str(tmp_path / "test_io.NA")
     # no extension error
     with pytest.raises(Exception):
-        _io.file_path = os.path.join(os.path.expanduser("~"), "test_io")
+        _io.file_path = str(tmp_path / "test_io")
     # directory
-    _io.file_path = os.path.join(os.path.expanduser("~"), "test_io.json")
-    assert _io.file_path == os.path.join(os.path.expanduser("~"), "test_io.json")
+    _io.file_path = str(tmp_path / "test_io.json")
+    assert _io.file_path == str(tmp_path / "test_io.json")
 
     # create io object with arguments
-    # _io = io.IO(file_name="test_io.json", folder_name="", root_path=os.path.expanduser("~"))
-    _io = io.IO(file_path=os.path.join(os.path.expanduser("~"), "test_io.json"))
+    _io = io.IO(file_path=str(tmp_path / "test_io.json"))
 
     test_data = {"test": "test"}
 
     # test locked files
-    _lock = FileLock(os.path.join(os.path.expanduser("~"), "test_io.json.lock"))
+    _lock = FileLock(str(tmp_path/"test_io.json.lock"))
     _lock.acquire()
     # write data to file
     with pytest.raises(Timeout):
@@ -93,21 +86,21 @@ def test_io():
     assert test_data == test_data_read
 
     # read data from file with different file_path
-    _io.read(file_path=os.path.join(os.path.expanduser("~"), "test_io.json"))
+    _io.read(file_path=str(tmp_path / "test_io.json"))
 
     # try to read data from file that does not exist
-    assert _io.file_exists(os.path.join(os.path.expanduser("~"), "test_io.NA")) == False
+    assert _io.file_exists(str(tmp_path / "test_io.NA")) == False
     with pytest.raises(Exception):
-        _io.read(file_path=os.path.join(os.path.expanduser("~"), "test_io.NA"))
+        _io.read(file_path=str(tmp_path/"test_io.NA"))
 
     # create the non existing folder
-    _io.folder_check(os.path.join(os.path.expanduser("~"), "test_io_folder", "test_io.json"))
+    _io.folder_check(str(tmp_path / "test_io_folder" / "test_io.json"))
 
     # delete the folder with os.rmdir
-    os.rmdir(os.path.join(os.path.expanduser("~"), "test_io_folder"))
+    os.rmdir(str(tmp_path / "test_io_folder"))
 
     # corrupt the test_io.json file purpose is to test the file_exists function
-    with open(os.path.join(os.path.expanduser("~"), "test_io.json"), "w") as f:
+    with open(tmp_path / "test_io.json", "w") as f:
         f.write("test")
 
     # test reading corrupted file

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -1,6 +1,22 @@
 """Tests for User related functions"""
-from .mockup import Mockup, clean_user
+from .mockup import Mockup
 from tik_manager4.objects import user
+import pytest
+
+
+@pytest.fixture(autouse=True, scope='function')
+def clean_user():
+    # NOTE: There are other modules where clean_user is used as the decorator
+    # under tests/mockup.py.  Since we don't wanna replicate this in each of
+    # these files, this piece of code can be moved to a `conftest.py` (see
+    # pytest documentation) and autouse may be disabled.  In this case, the
+    # clean_user fixture should be explicitly added to all test arguments.
+    # Explicit is better than implicit anyways...
+    m = Mockup()
+    m.backup_user()
+    user.User(common_directory=m.mockup_commons_path)
+    yield
+    m.revert()
 
 
 class TestUser(object):
@@ -11,14 +27,12 @@ class TestUser(object):
     import tik_manager4  # importing main checks the common folder definition, thats why its here
     tik = tik_manager4.initialize("Standalone")
 
-    @clean_user
     def test_reinitializing_user(self):
         """Tests validating the user information (again)"""
         self.tik.project.__init__()
         self.tik.user.__init__()
         assert self.tik.user._validate_user_data() == 1, "Existing user data failed to initialize"
 
-    @clean_user
     def test_query_users(self):
         """Tests getting the user list from commons database"""
         self.tik.project.__init__()
@@ -26,7 +40,6 @@ class TestUser(object):
         user_list = self.tik.user.commons.get_users()
         assert user_list
 
-    @clean_user
     def test_query_structures(self):
         """Tests if preset structures can be returned"""
         self.tik.project.__init__()
@@ -34,7 +47,6 @@ class TestUser(object):
         structures = self.tik.user.commons.get_project_structures()
         assert structures
 
-    @clean_user
     def test_get_active_user(self):
         """Tests getting the currently active user from user database"""
         self.tik.project.__init__()
@@ -42,7 +54,6 @@ class TestUser(object):
         assert self.tik.user.get() == "Generic"
         assert self.tik.project.guard.user == "Generic"
 
-    @clean_user
     def test_authenticating_user(self):
         """Tests authenticating the active user"""
         self.tik.project.__init__()
@@ -51,7 +62,6 @@ class TestUser(object):
         assert self.tik.user.authenticate("1234")
         assert self.tik.project.guard.is_authenticated == True
 
-    @clean_user
     def test_switching_users(self):
         """Tests switching between users"""
         self.tik.project.__init__()
@@ -63,7 +73,6 @@ class TestUser(object):
         assert self.tik.user.set("Generic", password="1234")
         assert self.tik.user.is_authenticated
 
-    @clean_user
     def test_adding_new_users(self):
         """Tests adding new users to database"""
         self.tik.project.__init__()
@@ -92,7 +101,6 @@ class TestUser(object):
         assert self.tik.user.set("Test_AdminUser", password="password") == ("Test_AdminUser", "Success")
         assert self.tik.user.create_new_user("Extra_User", "ext", "extra", 2) == (1, "Success")
 
-    @clean_user
     def test_change_user_password(self):
         self.tik.project.__init__()
         self.tik.user.__init__()
@@ -119,7 +127,6 @@ class TestUser(object):
         assert self.tik.user.change_user_password("1234", "awesome_password", user_name="Admin") == (1, "Success")
         assert self.tik.user.set("Admin", password="awesome_password") == ("Admin", "Success")
 
-    @clean_user
     def test_change_permission_levels(self):
         self.tik.project.__init__()
         self.tik.user.__init__()
@@ -139,7 +146,6 @@ class TestUser(object):
         assert self.tik.user.change_permission_level("Test_TaskUser", 3) == \
                (1, "Success")
 
-    @clean_user
     def test_delete_user(self):
         self.tik.project.__init__()
         self.tik.user.__init__()
@@ -155,7 +161,6 @@ class TestUser(object):
         assert self.tik.user.delete_user("Burhan Altintop") == (-1, "User Burhan Altintop does not exist. Aborting")
         assert self.tik.user.delete_user("Extra_User") == (1, "Success")
 
-    @clean_user
     def test_adding_new_project_bookmarks(self):
         self.tik.project.__init__()
         self.tik.user.__init__()
@@ -163,7 +168,6 @@ class TestUser(object):
         assert self.tik.user.add_project_bookmark("/path/to/projectB") == 1
         assert self.tik.user.add_project_bookmark("/path/to/projectB") == -1
 
-    @clean_user
     def test_delete_project_bookmarks(self):
         self.tik.project.__init__()
         self.tik.user.__init__()
@@ -173,7 +177,6 @@ class TestUser(object):
         assert len(self.tik.user.get_project_bookmarks()) == 0
         assert self.tik.user.delete_project_bookmark("/non/existing/project") == -1
 
-    @clean_user
     def test_get_project_bookmarks(self):
         self.tik.project.__init__()
         self.tik.user.__init__()

--- a/tik_manager4/core/filelog.py
+++ b/tik_manager4/core/filelog.py
@@ -2,26 +2,18 @@ import logging
 import os
 import datetime
 
-
 class Filelog(object):
+    # FIXME(ckutlu): We should definitely rethink the need for global state as
+    # part of the class variable.
     last_message = None
     last_message_type = None
 
-    def __init__(
-        self,
-        logname=None,
-        filename=None,
-        filedir=None,
-        date=True,
-        time=True,
-        size_cap=500000,
-        *args,
-        **kwargs
-    ):
+    def __init__(self, logname = None, filename=None, filedir=None, date=True, time=True, size_cap=500000, *args, **kwargs):
+        # FIXME(ckutlu): Perhaps we can live with only a path argument
         super(Filelog, self).__init__()
         self.fileName = filename if filename else "defaultLog"
         self.fileDir = filedir if filedir else os.path.expanduser("~")
-        self.filePath = os.path.join(self.fileDir, "%s.log" % self.fileName)
+        self.filePath = os.path.join(self.fileDir, "%s.log" %self.fileName)
         self.logger = logging.getLogger(self.fileName)
         self.logger.setLevel(logging.DEBUG)
         self.log_name = logname if logname else self.fileName
@@ -51,7 +43,7 @@ class Filelog(object):
             if self.is_time:
                 now_data.append(now.strftime("%H:%M"))
             now_string = " - ".join(now_data)
-            return "%s - " % now_string
+            return "%s - " %now_string
         else:
             return ""
 
@@ -65,7 +57,7 @@ class Filelog(object):
         return self.log_name
 
     def info(self, msg):
-        stamped_msg = "%sINFO    : %s" % (self._get_now(), msg)
+        stamped_msg = "%sINFO    : %s" %(self._get_now(), msg)
         self._start_logging()
         self.logger.info(stamped_msg)
         self.__set_last_message(msg, "info")
@@ -93,9 +85,9 @@ class Filelog(object):
     def title(self, msg):
         self._start_logging()
         self.logger.debug("")
-        self.logger.debug("=" * (len(msg)))
+        self.logger.debug("="*(len(msg)))
         self.logger.debug(msg)
-        self.logger.debug("=" * (len(msg)))
+        self.logger.debug("="*(len(msg)))
         # self.logger.debug("\n")
         self._end_logging()
         return msg
@@ -112,7 +104,7 @@ class Filelog(object):
     def seperator(self):
         self._start_logging()
         self.logger.debug("")
-        self.logger.debug("-" * 30)
+        self.logger.debug("-"*30)
         # self.logger.debug("\n")
         self._end_logging()
         return True


### PR DESCRIPTION
This PR adapts some tests to use `tmp_path` default pytest fixture and also introduces a custom fixture to demonstrate fixtures removing the need for `clean_user` as a decorator.  