### PR TITLE
Tik 87 saving works into their own folders

### DIFF
--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1,3 +1,4 @@
+# pylint: skip-file
 """Tests for Project related functions"""
 from pathlib import Path
 import shutil
@@ -5,41 +6,52 @@ from pprint import pprint
 import pytest
 from tik_manager4.core import utils
 
+
 class TestProject:
     """Uses a fresh mockup_common folder and test_project under user directory for all tests"""
+
     # import tik_manager4 # importing main checks the common folder definition, thats why its here
     # tik = tik_manager4.initialize("Standalone")
 
-    @pytest.fixture(scope='function')
+    @pytest.fixture(scope="function")
     def project_default_path(self):
         project_path = Path(utils.get_home_dir(), "TM4_default")
         if project_path.exists():
             shutil.rmtree(str(project_path))
         return str(project_path)
 
-    @pytest.fixture(scope='function')
+    @pytest.fixture(scope="function")
     def project_path(self):
         project_path = Path(utils.get_home_dir(), "t4_test_project_DO_NOT_USE")
         if project_path.exists():
             shutil.rmtree(str(project_path))
         return str(project_path)
 
-    @pytest.fixture(scope='function')
+    @pytest.fixture(scope="function")
     def project_manual_path(self):
         project_path = Path(utils.get_home_dir(), "t4_test_manual_DO_NOT_USE")
         if project_path.exists():
             shutil.rmtree(str(project_path))
         return str(project_path)
 
-
     def test_default_project_paths(self, project_default_path, tik):
-        assert tik.project.path == "" # this is overridden by project class and must always return empty string
+        assert (
+            tik.project.path == ""
+        )  # this is overridden by project class and must always return empty string
         tik.set_project(project_default_path)
-        assert tik.project.absolute_path == str(Path(utils.get_home_dir(), "TM4_default"))
-        assert tik.project.database_path == str(Path(utils.get_home_dir(), "TM4_default", "tikDatabase"))
+        assert tik.project.absolute_path == str(
+            Path(utils.get_home_dir(), "TM4_default")
+        )
+        assert tik.project.database_path == str(
+            Path(utils.get_home_dir(), "TM4_default", "tikDatabase")
+        )
         assert tik.project.name == "TM4_default"
-        assert tik.project.guard.project_root == str(Path(utils.get_home_dir(), "TM4_default"))
-        assert tik.project.guard.database_root == str(Path(utils.get_home_dir(), "TM4_default", "tikDatabase"))
+        assert tik.project.guard.project_root == str(
+            Path(utils.get_home_dir(), "TM4_default")
+        )
+        assert tik.project.guard.database_root == str(
+            Path(utils.get_home_dir(), "TM4_default", "tikDatabase")
+        )
 
     def test_create_new_project(self, project_path, tik):
         # no user permission
@@ -56,8 +68,15 @@ class TestProject:
         assert tik.create_project(project_path, structure_template="hedehot") == 1
         assert tik.create_project(project_path, structure_template="empty") == -1
         shutil.rmtree(project_path)
-        assert tik.create_project(project_path, structure_template="asset_shot", resolution=[3840, 2160],
-                                       fps=30) == 1
+        assert (
+            tik.create_project(
+                project_path,
+                structure_template="asset_shot",
+                resolution=[3840, 2160],
+                fps=30,
+            )
+            == 1
+        )
         return project_path
 
     def test_set_project_with_arguments(self, project_path, tik):
@@ -78,7 +97,9 @@ class TestProject:
         new_sub = tik.project.create_sub_project("testSub", parent_path="")
         assert new_sub.path == "testSub"
 
-        another_sub = tik.project.create_sub_project("anotherSub", parent_uid=new_sub.id)
+        another_sub = tik.project.create_sub_project(
+            "anotherSub", parent_uid=new_sub.id
+        )
         assert another_sub.path == "testSub/anotherSub"
 
         # test the parent.name and parent.id
@@ -87,7 +108,10 @@ class TestProject:
 
         # try creating an existing one
         assert tik.project.create_sub_project("anotherSub", parent_uid=new_sub.id) == -1
-        assert tik.log.get_last_message() == ("anotherSub already exist in sub-projects of testSub", "warning")
+        assert tik.log.get_last_message() == (
+            "anotherSub already exist in sub-projects of testSub",
+            "warning",
+        )
 
     def test_edit_sub_project(self, project_path, tik):
         """Test editing sub-projects with parent id and path"""
@@ -101,44 +125,66 @@ class TestProject:
 
         # no permission test
         tik.user.set("Generic")
-        assert tik.project.edit_sub_project(uid=new_sub.id, name="testEditedSub", resolution=[4096, 2144], fps=39) == -1
+        assert (
+            tik.project.edit_sub_project(
+                uid=new_sub.id, name="testEditedSub", resolution=[4096, 2144], fps=39
+            )
+            == -1
+        )
         tik.user.set("Admin", "1234")
         # test with uid
-        assert tik.project.edit_sub_project(uid=new_sub.id, name="testEditedSub", resolution=[4096, 2144], fps=39) == 1
+        assert (
+            tik.project.edit_sub_project(
+                uid=new_sub.id, name="testEditedSub", resolution=[4096, 2144], fps=39
+            )
+            == 1
+        )
 
         # test with path
-        assert tik.project.edit_sub_project(path=new_sub.path, name="testEditedSub", resolution=[4096, 2144], fps=40, lens=50) == 1
+        assert (
+            tik.project.edit_sub_project(
+                path=new_sub.path,
+                name="testEditedSub",
+                resolution=[4096, 2144],
+                fps=40,
+                lens=50,
+            )
+            == 1
+        )
 
-    def test_create_a_shot_asset_project_structure(self, project_manual_path, tik, print_results=False):
+    def test_create_a_shot_asset_project_structure(
+        self, project_manual_path, tik, print_results=False
+    ):
 
         tik.user.set("Admin", password="1234")
         tik.create_project(project_manual_path, structure_template="empty")
         tik.set_project(project_manual_path)
-
-        # asset_categories = ["Model", "LookDev", "Rig"]
-        # shot_categories = ["Layout", "Animation", "Lighting", "Render"]
 
         assets = tik.project.add_sub_project("Assets", mode="asset")
         chars = assets.add_sub_project("Characters", fps=60)
         props = assets.add_sub_project("Props", metatest="uberMetaTestingen")
         env = assets.add_sub_project("Environment")
 
-        leaf_assets = [chars.add_sub_project("Soldier"),
-                       props.add_sub_project("Rifle"),
-                       props.add_sub_project("Knife"),
-                       env.add_sub_project("Tree"),
-                       env.add_sub_project("Ground"),
-                       env.add_sub_project("GroundA"),
-                       env.add_sub_project("GroundB"),
-                       env.add_sub_project("GroundC"),
-                       env.add_sub_project("GroundD"),
-                       ]
-
+        leaf_assets = [
+            chars.add_sub_project("Soldier"),
+            props.add_sub_project("Rifle"),
+            props.add_sub_project("Knife"),
+            env.add_sub_project("Tree"),
+            env.add_sub_project("Ground"),
+            env.add_sub_project("GroundA"),
+            env.add_sub_project("GroundB"),
+            env.add_sub_project("GroundC"),
+            env.add_sub_project("GroundD"),
+        ]
 
         shots = tik.project.add_sub_project("Shots", mode="shot")
         sequence_a = shots.add_sub_project("SequenceA")
-        leaf_shots = [sequence_a.add_sub_project("SHOT_010"), sequence_a.add_sub_project("SHOT_020"),
-                      sequence_a.add_sub_project("SHOT_030"), sequence_a.add_sub_project("SHOT_040"),]
+        leaf_shots = [
+            sequence_a.add_sub_project("SHOT_010"),
+            sequence_a.add_sub_project("SHOT_020"),
+            sequence_a.add_sub_project("SHOT_030"),
+            sequence_a.add_sub_project("SHOT_040"),
+        ]
 
         sequence_b = shots.add_sub_project("SequenceB")
         leaf_shots.append(sequence_b.add_sub_project("SHOT_010"))
@@ -153,20 +199,22 @@ class TestProject:
 
     def test_validating_existing_project(self, project_manual_path, tik):
         """Tests reading an existing project structure and compares it to the created one on-the-fly"""
-        test_project_path = self.test_create_a_shot_asset_project_structure(project_manual_path, tik)
+        test_project_path = self.test_create_a_shot_asset_project_structure(
+            project_manual_path, tik
+        )
         current_subtree = tik.project.get_sub_tree()
-        # tik.project.__init__()
-        # tik.user.__init__()
-
-        # print(test_project_path)
         tik.set_project(test_project_path)
         existing_subtree = tik.project.get_sub_tree()
         pprint(existing_subtree)
-        assert current_subtree == existing_subtree, "Read and Write of project structure does not match"
+        assert (
+            current_subtree == existing_subtree
+        ), "Read and Write of project structure does not match"
 
     def test_deleting_sub_projects(self, project_manual_path, tik):
         """Tests deleting the sub-projects"""
-        test_project_path = self.test_create_a_shot_asset_project_structure(project_manual_path, tik, print_results=False)
+        test_project_path = self.test_create_a_shot_asset_project_structure(
+            project_manual_path, tik, print_results=False
+        )
         tik.set_project(test_project_path)
         tik.user.set("Generic")
         assert tik.project.delete_sub_project(path="Assets/Props") == -1
@@ -201,14 +249,16 @@ class TestProject:
         assert sub_by_id.path == "Assets"
         assert sub_by_path == sub_by_id
 
-        #non existing path
+        # non existing path
         assert tik.project.find_sub_by_path("Burhan/Altintop") == -1
         assert tik.project.find_sub_by_id(123123123123123123123) == -1
 
     def test_find_subs_by_wildcard(self, project_manual_path, tik):
-        test_project_path = self.test_create_a_shot_asset_project_structure(project_manual_path, tik, print_results=False)
+        test_project_path = self.test_create_a_shot_asset_project_structure(
+            project_manual_path, tik, print_results=False
+        )
         tik.set_project(test_project_path)
-        shots = (tik.project.find_subs_by_wildcard("SHOT_*"))
+        shots = tik.project.find_subs_by_wildcard("SHOT_*")
         assert shots
         assert len(shots) == 7
 
@@ -220,42 +270,78 @@ class TestProject:
         path = tik.project.get_path_by_uid(uid)
         assert path == compare_path
 
-        #non existing path
+        # non existing path
         assert tik.project.get_uid_by_path("Burhan/Altintop") == -1
         assert tik.project.get_path_by_uid(123123123123123123123) == -1
 
     def test_creating_and_adding_new_tasks(self, project_manual_path, tik):
-        test_project_path = self.test_create_a_shot_asset_project_structure(project_manual_path, tik, print_results=False)
+        test_project_path = self.test_create_a_shot_asset_project_structure(
+            project_manual_path, tik, print_results=False
+        )
         tik.set_project(test_project_path)
 
         # create a task from the main project
-        task = tik.project.create_task("superman", categories=["Model", "Rig", "LookDev"], parent_path="Assets/Characters/Soldier")
+        task = tik.project.create_task(
+            "superman",
+            categories=["Model", "Rig", "LookDev"],
+            parent_path="Assets/Characters/Soldier",
+        )
         assert task.name == "superman"
         assert task.creator == "Admin"
         assert list(task.categories.keys()) == ["Model", "Rig", "LookDev"]
         assert task.type == "asset"
 
         # create a task directly from a sub-project
-        task = tik.project.subs["Assets"].subs["Characters"].subs["Soldier"].add_task("batman", categories=["Model", "Rig", "LookDev"], task_type="Asset")
+        task = (
+            tik.project.subs["Assets"]
+            .subs["Characters"]
+            .subs["Soldier"]
+            .add_task(
+                "batman", categories=["Model", "Rig", "LookDev"], task_type="Asset"
+            )
+        )
 
         # TODO make a test to create illegal categories (not defined in the category definitions)
 
         # try to create a duplicate task
-        assert tik.project.create_task("superman", categories=["Model", "Rig", "LookDev"], parent_path="Assets/Characters/Soldier") == -1
+        assert (
+            tik.project.create_task(
+                "superman",
+                categories=["Model", "Rig", "LookDev"],
+                parent_path="Assets/Characters/Soldier",
+            )
+            == -1
+        )
 
         # check if the user permissions check works
         tik.user.set("Generic", password="1234")
-        assert tik.project.create_task("this_asset_shouldnt_exist", categories=["Model", "Rig", "LookDev"], parent_path="Assets/Characters/Soldier") == -1
+        assert (
+            tik.project.create_task(
+                "this_asset_shouldnt_exist",
+                categories=["Model", "Rig", "LookDev"],
+                parent_path="Assets/Characters/Soldier",
+            )
+            == -1
+        )
         # check if the log message is correct
-        assert tik.log.get_last_message() == ('This user does not have permissions for this action', 'warning')
+        assert tik.log.get_last_message() == (
+            "This user does not have permissions for this action",
+            "warning",
+        )
         tik.user.set("Admin", password="1234")
 
     def test_edit_task(self, project_manual_path, tik):
-        test_project_path = self.test_create_a_shot_asset_project_structure(project_manual_path, tik ,print_results=False)
+        test_project_path = self.test_create_a_shot_asset_project_structure(
+            project_manual_path, tik, print_results=False
+        )
         tik.set_project(test_project_path)
 
         # create a task from the main project
-        task = tik.project.create_task("Poseidon", categories=["Model", "Rig", "LookDev"], parent_path="Assets/Characters/Soldier")
+        task = tik.project.create_task(
+            "Poseidon",
+            categories=["Model", "Rig", "LookDev"],
+            parent_path="Assets/Characters/Soldier",
+        )
 
         assert task.name == "Poseidon"
         assert task.creator == "Admin"
@@ -264,25 +350,56 @@ class TestProject:
 
         # no permissions
         tik.user.set("Generic", password="1234")
-        assert task.edit(name="Aquaman", categories=["Model", "Rig", "LookDev", "Animation"], task_type="Shot") == -1
-        assert tik.log.get_last_message() == ('This user does not have permissions for this action', 'warning')
+        assert (
+            task.edit(
+                name="Aquaman",
+                categories=["Model", "Rig", "LookDev", "Animation"],
+                task_type="Shot",
+            )
+            == -1
+        )
+        assert tik.log.get_last_message() == (
+            "This user does not have permissions for this action",
+            "warning",
+        )
         tik.user.set("Admin", password="1234")
 
         # existing task name
-        existing_task = tik.project.create_task("Wonderboy", categories=["Model", "Rig", "LookDev"],
-                                            parent_path="Assets/Characters/Soldier")
-        assert task.edit(name="Wonderboy", categories=["Model", "Rig", "LookDev", "Animation"], task_type="Shot") == -1
-        assert tik.log.get_last_message() == ("Task name 'Wonderboy' already exists in sub 'Soldier'.", 'error')
+        existing_task = tik.project.create_task(
+            "Wonderboy",
+            categories=["Model", "Rig", "LookDev"],
+            parent_path="Assets/Characters/Soldier",
+        )
+        assert (
+            task.edit(
+                name="Wonderboy",
+                categories=["Model", "Rig", "LookDev", "Animation"],
+                task_type="Shot",
+            )
+            == -1
+        )
+        assert tik.log.get_last_message() == (
+            "Task name 'Wonderboy' already exists in sub 'Soldier'.",
+            "error",
+        )
 
         # wrong category type
         with pytest.raises(Exception):
             task.edit(name="Aquaman", categories="ThisIsWrong", task_type="Shot")
         # category not defined
         with pytest.raises(Exception):
-            task.edit(name="Aquaman", categories=["Model", "Rig", "LookDev", "Animation", "ThisIsWrong"], task_type="Shot")
+            task.edit(
+                name="Aquaman",
+                categories=["Model", "Rig", "LookDev", "Animation", "ThisIsWrong"],
+                task_type="Shot",
+            )
 
         # edit the task
-        task.edit(name="Aquaman", categories=["Model", "Rig", "LookDev", "Animation"], task_type="Shot")
+        task.edit(
+            name="Aquaman",
+            categories=["Model", "Rig", "LookDev", "Animation"],
+            task_type="Shot",
+        )
 
         assert list(task.categories.keys()) == ["Model", "Rig", "LookDev", "Animation"]
         assert task.name == "Aquaman"
@@ -291,73 +408,147 @@ class TestProject:
     def test_adding_categories(self, project_manual_path, tik):
         self.test_creating_and_adding_new_tasks(project_manual_path, tik)
         # add a category
-        _test_tasks = tik.project.subs["Assets"].subs["Characters"].subs["Soldier"].tasks
+        _test_tasks = (
+            tik.project.subs["Assets"].subs["Characters"].subs["Soldier"].tasks
+        )
 
         # try to add category without permissions
         tik.user.set("Generic", password="1234")
-        assert tik.project.subs["Assets"].subs["Characters"].subs["Soldier"].tasks["batman"].add_category("Temp") == -1
+        assert (
+            tik.project.subs["Assets"]
+            .subs["Characters"]
+            .subs["Soldier"]
+            .tasks["batman"]
+            .add_category("Temp")
+            == -1
+        )
         tik.user.set("Admin", password="1234")
         # add the Gotham category to Batman task
-        assert tik.project.subs["Assets"].subs["Characters"].subs["Soldier"].tasks["batman"].add_category("Temp")
+        assert (
+            tik.project.subs["Assets"]
+            .subs["Characters"]
+            .subs["Soldier"]
+            .tasks["batman"]
+            .add_category("Temp")
+        )
 
         # try to add a duplicate category
-        assert tik.project.subs["Assets"].subs["Characters"].subs["Soldier"].tasks["batman"].add_category("Temp") == -1
+        assert (
+            tik.project.subs["Assets"]
+            .subs["Characters"]
+            .subs["Soldier"]
+            .tasks["batman"]
+            .add_category("Temp")
+            == -1
+        )
         # check the log message
-        assert tik.log.get_last_message() == ("Category 'Temp' already exists in task 'batman'.", 'warning')
+        assert tik.log.get_last_message() == (
+            "Category 'Temp' already exists in task 'batman'.",
+            "warning",
+        )
 
         # try to add a category that is not defined in the category definitions
         with pytest.raises(Exception) as e_info:
-            tik.project.subs["Assets"].subs["Characters"].subs["Soldier"].tasks["batman"].add_category("Burhan")
+            tik.project.subs["Assets"].subs["Characters"].subs["Soldier"].tasks[
+                "batman"
+            ].add_category("Burhan")
         # check the log message
-        assert tik.log.get_last_message() == ("Category 'Burhan' is not defined in category definitions.", 'error')
+        assert tik.log.get_last_message() == (
+            "Category 'Burhan' is not defined in category definitions.",
+            "error",
+        )
 
     def test_order_categories(self, project_manual_path, tik):
         self.test_creating_and_adding_new_tasks(project_manual_path, tik)
 
         # order categories
-        _test_tasks = tik.project.subs["Assets"].subs["Characters"].subs["Soldier"].tasks
-        assert tik.project.subs["Assets"].subs["Characters"].subs["Soldier"].tasks["superman"].order_categories(["Model", "LookDev", "Rig"]) == 1
+        _test_tasks = (
+            tik.project.subs["Assets"].subs["Characters"].subs["Soldier"].tasks
+        )
+        assert (
+            tik.project.subs["Assets"]
+            .subs["Characters"]
+            .subs["Soldier"]
+            .tasks["superman"]
+            .order_categories(["Model", "LookDev", "Rig"])
+            == 1
+        )
 
         # try to order categories without permissions
         tik.user.set("Generic", password="1234")
-        assert tik.project.subs["Assets"].subs["Characters"].subs["Soldier"].tasks["superman"].order_categories(["Model", "LookDev", "Rig"]) == -1
+        assert (
+            tik.project.subs["Assets"]
+            .subs["Characters"]
+            .subs["Soldier"]
+            .tasks["superman"]
+            .order_categories(["Model", "LookDev", "Rig"])
+            == -1
+        )
         tik.user.set("Admin", password="1234")
 
         # try to order categories with a wrong length
         with pytest.raises(Exception) as e_info:
-            tik.project.subs["Assets"].subs["Characters"].subs["Soldier"].tasks["superman"].order_categories(["LookDev", "Model"])
+            tik.project.subs["Assets"].subs["Characters"].subs["Soldier"].tasks[
+                "superman"
+            ].order_categories(["LookDev", "Model"])
         # check the log message
-        assert tik.log.get_last_message() == ("New order list is not the same length as the current categories list.", 'error')
+        assert tik.log.get_last_message() == (
+            "New order list is not the same length as the current categories list.",
+            "error",
+        )
 
         # try to order categories with an item not in the current categories list
         with pytest.raises(Exception) as e_info:
-            tik.project.subs["Assets"].subs["Characters"].subs["Soldier"].tasks["superman"].order_categories(["Model", "LookDev", "Temp"])
+            tik.project.subs["Assets"].subs["Characters"].subs["Soldier"].tasks[
+                "superman"
+            ].order_categories(["Model", "LookDev", "Temp"])
         # check the log message
-        assert tik.log.get_last_message() == ("New order list contains a category that is not in the current categories list.", 'error')
+        assert tik.log.get_last_message() == (
+            "New order list contains a category that is not in the current categories list.",
+            "error",
+        )
 
     def test_scanning_tasks(self, project_manual_path, tik):
         self.test_creating_and_adding_new_tasks(project_manual_path, tik)
 
         # scan the tasks
-        assert tik.project.subs["Assets"].subs["Characters"].subs["Soldier"].scan_tasks()
+        assert (
+            tik.project.subs["Assets"].subs["Characters"].subs["Soldier"].scan_tasks()
+        )
 
         # modify one of the tasks and scan again
         # no permission
-        tik.project.subs["Assets"].subs["Characters"].subs["Soldier"].tasks["superman"].add_category("Temp")
+        tik.project.subs["Assets"].subs["Characters"].subs["Soldier"].tasks[
+            "superman"
+        ].add_category("Temp")
         tik.user.set("Admin", password=1234)
-        assert tik.project.subs["Assets"].subs["Characters"].subs["Soldier"].scan_tasks()
+        assert (
+            tik.project.subs["Assets"].subs["Characters"].subs["Soldier"].scan_tasks()
+        )
 
     def test_creating_works(self, project_manual_path, tik):
         self.test_creating_and_adding_new_tasks(project_manual_path, tik)
 
         tik.user.set("Admin", 1234)
 
-        #create some addigional tasks
+        # create some addigional tasks
         asset_categories = ["Model", "Rig", "LookDev"]
 
-        bizarro_task = tik.project.create_task("bizarro", categories=asset_categories, parent_path="Assets/Characters/Soldier")
-        ultraman_task = tik.project.create_task("ultraman", categories=asset_categories, parent_path="Assets/Characters/Soldier")
-        superboy_task = tik.project.create_task("superboy", categories=asset_categories, parent_path="Assets/Characters/Soldier")
+        bizarro_task = tik.project.create_task(
+            "bizarro",
+            categories=asset_categories,
+            parent_path="Assets/Characters/Soldier",
+        )
+        ultraman_task = tik.project.create_task(
+            "ultraman",
+            categories=asset_categories,
+            parent_path="Assets/Characters/Soldier",
+        )
+        superboy_task = tik.project.create_task(
+            "superboy",
+            categories=asset_categories,
+            parent_path="Assets/Characters/Soldier",
+        )
 
         # check if a category is empty or not
         assert superboy_task.categories["Model"].is_empty() == True
@@ -369,82 +560,240 @@ class TestProject:
 
         # create a work
         bizarro_task.categories["Model"].create_work("default")
-        bizarro_task.categories["Model"].create_work("main", file_format=".txt", notes="This is a note. Very default.")
-        bizarro_task.categories["Model"].create_work("lod300", file_format=".txt", notes="This is a note. Lod300.")
+        bizarro_task.categories["Model"].create_work(
+            "main", file_format=".txt", notes="This is a note. Very default."
+        )
+        bizarro_task.categories["Model"].create_work(
+            "lod300", file_format=".txt", notes="This is a note. Lod300."
+        )
 
         bizarro_task.categories["Rig"].create_work("default")
-        bizarro_task.categories["Rig"].create_work("main", file_format=".txt", notes="This is a note. Very default Rig.")
-        bizarro_task.categories["Rig"].create_work("lod300", file_format=".txt", notes="This is a note. Lod300 Rig.")
+        bizarro_task.categories["Rig"].create_work(
+            "main", file_format=".txt", notes="This is a note. Very default Rig."
+        )
+        bizarro_task.categories["Rig"].create_work(
+            "lod300", file_format=".txt", notes="This is a note. Lod300 Rig."
+        )
 
-        ultraman_task.categories["Model"].create_work("varA", notes="This is a Model note for varA")
-        ultraman_task.categories["Model"].create_work("varB", notes="This is a Model note for varB")
-        ultraman_task.categories["Model"].create_work("varC", notes="This is a Model note for varC")
+        ultraman_task.categories["Model"].create_work(
+            "varA", notes="This is a Model note for varA"
+        )
+        ultraman_task.categories["Model"].create_work(
+            "varB", notes="This is a Model note for varB"
+        )
+        ultraman_task.categories["Model"].create_work(
+            "varC", notes="This is a Model note for varC"
+        )
 
-        ultraman_task.categories["Rig"].create_work("varA", notes="This is a note for varA")
-        ultraman_task.categories["Rig"].create_work("varB", notes="This is a note for varB")
-        ultraman_task.categories["Rig"].create_work("varC", notes="This is a note for varC")
+        ultraman_task.categories["Rig"].create_work(
+            "varA", notes="This is a note for varA"
+        )
+        ultraman_task.categories["Rig"].create_work(
+            "varB", notes="This is a note for varB"
+        )
+        ultraman_task.categories["Rig"].create_work(
+            "varC", notes="This is a note for varC"
+        )
 
         # when an existing work name used, it should iterate a version over existing work
-        this_should_have_2_versions = ultraman_task.categories["Rig"].create_work("varC", notes="this is a complete new version of varC")
+        this_should_have_2_versions = ultraman_task.categories["Rig"].create_work(
+            "varC", notes="this is a complete new version of varC"
+        )
         assert this_should_have_2_versions.version_count == 2
+
+        # try to create a new version without permissions
+        tik.user.set("Observer", password="1234")
+        assert ultraman_task.categories["Rig"].create_work(
+            "varC", notes="this is a complete new version of varC"
+        ) == -1
+
+        tik.user.set("Admin", password="1234")
+        # try to create a new version with a wrong format
+        with pytest.raises(ValueError) as e_info:
+            ultraman_task.categories["Rig"].create_work(
+                "varC", file_format=".burhan", notes="this is a complete new version of varC"
+            )
+            assert e_info == "File format is not valid."
+
+
+    def test_find_works_by_wildcard(self, project_manual_path, tik):
+        self.test_creating_works(project_manual_path, tik)
+        lod300_works = (
+            tik.project.subs["Assets"]
+            .subs["Characters"]
+            .subs["Soldier"]
+            .tasks["bizarro"]
+            .find_works_by_wildcard("*lod300")
+        )
+
+        # there should be 2 lod300 works. One in Model and one in Rig
+        assert len(lod300_works) == 2
+
+        # find a work by wildcard in a specific category
+        model_lod300 = (
+            tik.project.subs["Assets"]
+            .subs["Characters"]
+            .subs["Soldier"]
+            .tasks["bizarro"]
+            .categories["Model"]
+            .get_works_by_wildcard("*_lod300")
+        )
+
+        # there should be only one lod300 work in Model category
+        assert len(model_lod300) == 1
+        assert model_lod300[0].name == "bizarro_Model_lod300"
 
     def test_scanning_works(self, project_manual_path, tik):
         self.test_creating_works(project_manual_path, tik)
 
         # scan all works
-        assert tik.project.subs["Assets"].subs["Characters"].subs["Soldier"].tasks["bizarro"].categories["Model"].scan_works(all_dcc=True)
+        initial_scan = tik.project.subs["Assets"].subs["Characters"].subs["Soldier"].tasks["bizarro"].categories["Model"].scan_works()
+        assert initial_scan
+        initial_scan_count = int(len(initial_scan.keys()))
+        assert initial_scan_count== 3
 
         # add another work version to the first work and scan again
         _w = tik.project.subs["Assets"].subs["Characters"].subs["Soldier"].tasks["bizarro"].categories["Model"]._works
-        work_obj = (_w[list(_w.keys())[0]])
+        work_obj = _w[list(_w.keys())[0]]
         work_obj.new_version()
 
-        assert tik.project.subs["Assets"].subs["Characters"].subs["Soldier"].tasks["bizarro"].categories["Model"].scan_works(all_dcc=True)
+        second_scan = tik.project.subs["Assets"].subs["Characters"].subs["Soldier"].tasks["bizarro"].categories["Model"].scan_works()
+        assert second_scan
+        second_scan_count = int(len(second_scan.keys()))
+        assert second_scan_count == initial_scan_count
 
-        # override the guard.dcc
-        # tik.project.guard._dcc = "Maya"
-        # assert tik.project.subs["Assets"].subs["Characters"].subs["Soldier"].tasks["bizarro"].categories["Model"].scan_works(all_dcc=False) == {}
+        # temporarily disable (change the extension) of one of the work paths and scan again
+        _temp = work_obj.settings_file.rename(work_obj.settings_file.with_suffix(".bck"))
+        # scan again and compare with the previous scan
+        third_scan = tik.project.subs["Assets"].subs["Characters"].subs["Soldier"].tasks["bizarro"].categories["Model"].scan_works()
+        assert third_scan
+        third_scan_count = int(len(third_scan.keys()))
+        assert third_scan_count == second_scan_count - 1
+
+    def test_deleting_works(self, project_manual_path, tik):
+        self.test_creating_works(project_manual_path, tik)
+
+        # delete a work
+        model_category = tik.project.subs["Assets"].subs["Characters"].subs["Soldier"].tasks["bizarro"].categories["Model"]
+        works = model_category.scan_works()
+        target_work = list(works.keys())[0]
+
+        # try to delete a work without permissions
+        tik.user.set("Generic", password="1234")
+        assert model_category.delete_work(target_work) == -1
+
+        tik.user.set("Admin", password="1234")
+        # try to delete a non existing work
+        assert model_category.delete_work("burhan_altintop") == -1
+
+        # delete the work
+        assert model_category.delete_work(target_work) == 1
 
     def test_deleting_empty_task(self, project_manual_path, tik):
         self.test_creating_and_adding_new_tasks(project_manual_path, tik)
 
         # try to delete a task without permissions
         tik.user.set("Generic", password="1234")
-        assert tik.project.subs["Assets"].subs["Characters"].subs["Soldier"].delete_task("superman") == -1
+        assert (
+            tik.project.subs["Assets"]
+            .subs["Characters"]
+            .subs["Soldier"]
+            .delete_task("superman")
+            == -1
+        )
         # check if the log message is correct
-        assert tik.log.get_last_message() == ('This user does not have permissions for this action', 'warning')
+        assert tik.log.get_last_message() == (
+            "This user does not have permissions for this action",
+            "warning",
+        )
         # try to delete a non-existing task
-        assert tik.project.subs["Assets"].subs["Characters"].subs["Soldier"].delete_task("this_task_doesnt_exist") == -1
+        assert (
+            tik.project.subs["Assets"]
+            .subs["Characters"]
+            .subs["Soldier"]
+            .delete_task("this_task_doesnt_exist")
+            == -1
+        )
 
         # delete the task
         tik.user.set("Admin", password="1234")
-        assert tik.project.subs["Assets"].subs["Characters"].subs["Soldier"].delete_task("superman") == 1
+        assert (
+            tik.project.subs["Assets"]
+            .subs["Characters"]
+            .subs["Soldier"]
+            .delete_task("superman")
+            == 1
+        )
 
     def test_deleting_empty_categories(self, project_manual_path, tik):
         self.test_adding_categories(project_manual_path, tik)
 
         # try to delete a category without permissions
         tik.user.set("Generic", password="1234")
-        assert tik.project.subs["Assets"].subs["Characters"].subs["Soldier"].tasks["batman"].delete_category("Model") == -1
+        assert (
+            tik.project.subs["Assets"]
+            .subs["Characters"]
+            .subs["Soldier"]
+            .tasks["batman"]
+            .delete_category("Model")
+            == -1
+        )
         tik.user.set("Admin", password="1234")
         # try to delete a non-existing category
-        assert tik.project.subs["Assets"].subs["Characters"].subs["Soldier"].tasks["batman"].delete_category("Burhan") == -1
+        assert (
+            tik.project.subs["Assets"]
+            .subs["Characters"]
+            .subs["Soldier"]
+            .tasks["batman"]
+            .delete_category("Burhan")
+            == -1
+        )
         # delete the Gotham category from Batman task
-        tik.project.subs["Assets"].subs["Characters"].subs["Soldier"].tasks["batman"].delete_category("Gotham")
-        assert "Gotham" not in tik.project.subs["Assets"].subs["Characters"].subs["Soldier"].tasks["batman"].categories.keys()
+        tik.project.subs["Assets"].subs["Characters"].subs["Soldier"].tasks[
+            "batman"
+        ].delete_category("Gotham")
+        assert (
+            "Gotham"
+            not in tik.project.subs["Assets"]
+            .subs["Characters"]
+            .subs["Soldier"]
+            .tasks["batman"]
+            .categories.keys()
+        )
 
     def test_deleting_non_empty_categories(self, project_manual_path, tik):
         self.test_adding_categories(project_manual_path, tik)
         # add a version to the Gotham category
-        tik.project.subs["Assets"].subs["Characters"].subs["Soldier"].tasks["batman"].categories["Temp"].create_work("test_work")
+        tik.project.subs["Assets"].subs["Characters"].subs["Soldier"].tasks[
+            "batman"
+        ].categories["Temp"].create_work("test_work")
         # try to delete a non-empty category
         tik.user.set("Admin", password="1234")
-        assert tik.project.subs["Assets"].subs["Characters"].subs["Soldier"].tasks["batman"].categories["Temp"].is_empty() == False
-        tik.project.subs["Assets"].subs["Characters"].subs["Soldier"].tasks["batman"].delete_category("Temp")
+        assert (
+            tik.project.subs["Assets"]
+            .subs["Characters"]
+            .subs["Soldier"]
+            .tasks["batman"]
+            .categories["Temp"]
+            .is_empty()
+            == False
+        )
+        tik.project.subs["Assets"].subs["Characters"].subs["Soldier"].tasks[
+            "batman"
+        ].delete_category("Temp")
         # check the log message
-        assert tik.log.get_last_message() == ("Sending category 'Temp' from task 'batman' to purgatory.", 'warning')
+        assert tik.log.get_last_message() == (
+            "Sending category 'Temp' from task 'batman' to purgatory.",
+            "warning",
+        )
 
     def test_deleting_non_empty_tasks(self, project_manual_path, tik):
         self.test_creating_works(project_manual_path, tik)
         tik.user.set("Admin", password="1234")
-        assert tik.project.subs["Assets"].subs["Characters"].subs["Soldier"].delete_task("superboy") == 1
+        assert (
+            tik.project.subs["Assets"]
+            .subs["Characters"]
+            .subs["Soldier"]
+            .delete_task("superboy")
+            == 1
+        )

--- a/tik_manager4/objects/category.py
+++ b/tik_manager4/objects/category.py
@@ -38,17 +38,17 @@ class Category(Entity):
                 matched_items.append(work)
         return matched_items
 
-    def scan_works(self, all_dcc=False):
+    def scan_works(self):
         """Scan the category folder and return the works"""
         # get all files recursively, regardless of the dcc
-        _search_dir = self.get_abs_database_path()
-        _work_paths = list(Path(_search_dir).rglob("**/*.twork"))
+        search_dir = self.get_abs_database_path()
+        _work_paths = list(Path(search_dir).rglob("**/*.twork"))
 
         # add the file if it is new. if it is not new,
         # check the modified time and update if necessary
-        for _w_path, _w_data in dict(self._works).items():
-            if _w_path not in _work_paths:
-                self._works.pop(_w_path)
+        for w_path, _w_data in dict(self._works).items():
+            if w_path not in _work_paths:
+                self._works.pop(w_path)
         for _work_path in _work_paths:
             existing_work = self._works.get(_work_path, None)
             if not existing_work:
@@ -97,23 +97,22 @@ class Category(Entity):
         _work.new_version(file_format=file_format, notes=notes)
         return _work
 
-    def delete_work(self, name):
+    def delete_work(self, work_path):
         """Delete a work under the category."""
-
-        _work = self._works.get(name, None)
+        _work = self._works.get(Path(work_path), None)
         if not _work:
             LOG.warning(
-                "There is no work under this category with the name => %s" % name
+                "There is no work under this category with the name => %s" % work_path
             )
             return -1
 
         # if not, check if the user is the owner of the work
-        if self.guard.user != _work.creator or self.check_permissions(level=3):
+        if self.guard.user != _work.creator or not self.check_permissions(level=3):
             LOG.warning("You do not have the permission to delete this work")
             return -1
-
-        del self._works[name]
+        del self._works[work_path]
         _work.delete()
+        return 1
 
     def get_relative_work_path(self):
         """Return the relative path of the category"""

--- a/tik_manager4/objects/project.py
+++ b/tik_manager4/objects/project.py
@@ -202,11 +202,12 @@ class Project(Subproject):
         """
 
         _file_path_obj = Path(file_path)
-        parent_path = _file_path_obj.parent
+        work_path = _file_path_obj.parent
         # get the base name with extension
+        category_path = work_path.parent
         base_name = _file_path_obj.name
         try:
-            relative_path = parent_path.relative_to(self.absolute_path)
+            relative_path = category_path.relative_to(self.absolute_path)
         except ValueError:
             self.log.error("File path is not under the project root")
             return None, None
@@ -215,7 +216,8 @@ class Project(Subproject):
         for work_file in work_files:
             _work = Work(work_file)
             for nmb, version in enumerate(_work.versions):
-                if version.get("scene_path") == base_name:
+                resolved_path = Path(work_path.stem, base_name).as_posix()
+                if version.get("scene_path") == resolved_path:
                     return _work, version.get("version_number", nmb)
         return None, None
 

--- a/tik_manager4/objects/user.py
+++ b/tik_manager4/objects/user.py
@@ -154,7 +154,6 @@ class User(object):
         """Set the column sizes."""
         self.resume.edit_property("column_sizes", value)
 
-
     @classmethod
     def __set_authentication_status(cls, state):
         # cls._authenticated = state

--- a/tik_manager4/objects/work.py
+++ b/tik_manager4/objects/work.py
@@ -15,7 +15,6 @@ from tik_manager4 import dcc
 
 LOG = filelog.Filelog(logname=__name__, filename="tik_manager4")
 
-
 class Work(Settings, Entity):
     _dcc_handler = dcc.Dcc()
     object_type = "work"
@@ -155,7 +154,7 @@ class Work(Settings, Entity):
         # get filepath of current version
         version_number, version_name, thumbnail_name = self.construct_names(file_format)
 
-        abs_version_path = self.get_abs_project_path(version_name)
+        abs_version_path = self.get_abs_project_path(self.name, version_name)
         thumbnail_path = self.get_abs_database_path("thumbnails", thumbnail_name)
         Path(abs_version_path).parent.mkdir(parents=True, exist_ok=True)
 
@@ -176,13 +175,12 @@ class Work(Settings, Entity):
         self._dcc_handler.generate_thumbnail(thumbnail_path, 220, 124)
 
         # add it to the versions
-        # TODO: Make a version object instead of a dictionary
         version = {
             "version_number": version_number,
             "workstation": socket.gethostname(),
             "notes": notes,
             "thumbnail": Path("thumbnails", thumbnail_name).as_posix(),
-            "scene_path": str(version_name),
+            "scene_path": Path(self.name, str(version_name)).as_posix(),
             "user": self.guard.user,
             "previews": {},
             "file_format": file_format,

--- a/tik_manager4/objects/work.py
+++ b/tik_manager4/objects/work.py
@@ -375,7 +375,7 @@ class Work(Settings, Entity):
             _ingest_obj.file_path = abs_path
             _ingest_obj.reference()
 
-    def delete_work(self):
+    def delete(self):
         """Delete the work."""
         # TODO: implement this. This should move the work to the purgatory.
         pass


### PR DESCRIPTION
- now each 'work' has its own scene folder to prevent cluttering when reviewing the folders manually. 

---------------------
**This is a DESTRUCTIVE UPDATE against the backward compatibility.** 
The work versions saved earlier can be opened/imported/referenced regularly. Still, while versioning up, the resolver will not be able to resolve the database file from the scene file. One workaround is ingesting the new version into the work. Since this explicitly defines the work object, that will still work.