### PR TITLE
Tik 96 exposing metadata to ingest extract and validates

### DIFF
--- a/tik_manager4/core/settings.py
+++ b/tik_manager4/core/settings.py
@@ -73,9 +73,11 @@ class Settings():
         self._currentValue.update(data)
         self._originalValue = deepcopy(self._currentValue)
 
-    def update(self, data, dont_add_new_keys=True):
+    def update(self, data, add_missing_keys=False):
         """Updates the settings data"""
-        if dont_add_new_keys:
+        if isinstance(data, Settings):
+            data = data.get_data()
+        if not add_missing_keys:
             self._currentValue.update((k, data[k]) for k in self._currentValue.keys() & data.keys())
         else:
             self._currentValue.update(data)
@@ -154,3 +156,8 @@ class Settings():
         if self._fallback:
             self.initialize(self._io.read(self._fallback))
             self.apply_settings(force=True)
+    def __str__(self):
+        # return the type of the class and the current data
+        return f"{type(self).__name__}({self._currentValue})"
+    def __repr__(self):
+        return str(self._currentValue)

--- a/tik_manager4/dcc/houdini/extract/stl.py
+++ b/tik_manager4/dcc/houdini/extract/stl.py
@@ -16,6 +16,7 @@ class Stl(ExtractCore):
     nice_name = "STL"
     optional = False
     color = (100, 200, 0)
+    bundled = True
 
     # global exposed settings will apply ALL categories
     global_exposed_settings = {"discard_export_nodes": True}
@@ -23,7 +24,6 @@ class Stl(ExtractCore):
     def __init__(self):
         super().__init__()
         self._extension = ".stl"
-        self._bundled = True
         # we don't need to define category functions for STL
 
         self.export_geo_node_name = "tik_STL_export"

--- a/tik_manager4/dcc/houdini/ingest/stl.py
+++ b/tik_manager4/dcc/houdini/ingest/stl.py
@@ -11,10 +11,10 @@ class Stl(IngestCore):
     """Ingest STL."""
     nice_name = "Ingest STL"
     valid_extensions = [".stl"]
+    bundled = True
 
     def __init__(self):
         super(Stl, self).__init__()
-        self._bundled = True
 
     def _bring_in_default(self):
         """Import STL File."""

--- a/tik_manager4/dcc/ingest_core.py
+++ b/tik_manager4/dcc/ingest_core.py
@@ -3,6 +3,7 @@
 import importlib
 from pathlib import Path
 from tik_manager4.core import filelog
+from tik_manager4.objects.metadata import Metadata
 
 LOG = filelog.Filelog(logname=__name__, filename="tik_manager4")
 
@@ -12,6 +13,7 @@ class IngestCore:
 
     nice_name: str = ""
     valid_extensions: list = []
+    bundled: bool = False
 
     def __init__(self):
         self.name = str(Path(__file__).stem)
@@ -19,7 +21,8 @@ class IngestCore:
         self._status: str = "idle"
         self._file_path: str = ""
         self._namespace: str = ""
-        self._bundled: bool = False
+        # self._bundled: bool = False
+        self._metadata: Metadata
         self.category_functions: dict = {}
         self.category_reference_functions: dict = {}
 
@@ -64,9 +67,14 @@ class IngestCore:
         self._namespace = namespace
 
     @property
-    def bundled(self):
-        """Return if the ingest is a bundle or not."""
-        return self._bundled
+    def metadata(self):
+        """Return the metadata object."""
+        return self._metadata
+
+    @metadata.setter
+    def metadata(self, metadata):
+        """Set the metadata object."""
+        self._metadata = metadata
 
     @ingest_path.setter
     def ingest_path(self, ingest_path):

--- a/tik_manager4/dcc/max/extract/stl.py
+++ b/tik_manager4/dcc/max/extract/stl.py
@@ -12,11 +12,11 @@ class Stl(ExtractCore):
 
     nice_name = "STL"
     color = (100, 200, 0)
+    bundled = True
 
     def __init__(self):
         super().__init__()
         self._extension = ".stl"
-        self._bundled = True
         # we don't need to define category functions for STL
 
     @staticmethod

--- a/tik_manager4/dcc/max/ingest/stl.py
+++ b/tik_manager4/dcc/max/ingest/stl.py
@@ -11,10 +11,10 @@ class Stl(IngestCore):
     """Ingest STL to 3ds Max Scene."""
     nice_name = "Ingest STL"
     valid_extensions = [".stl"]
+    bundled = True
 
     def __init__(self):
         super(Stl, self).__init__()
-        self._bundled = True
 
     def _bring_in_default(self):
         all_files = list(Path(self.ingest_path).glob("*"))

--- a/tik_manager4/dcc/maya/extract/alembic.py
+++ b/tik_manager4/dcc/maya/extract/alembic.py
@@ -16,6 +16,8 @@ class Alembic(ExtractCore):
     _ranges = utils.get_ranges()
 
     # these are the exposed settings in the UI
+    # any metadata with the same key will OVERRIDE
+    # both exposed setting values and global exposed setting values
     exposed_settings = {
         "Animation": {
             "start_frame": _ranges[0],

--- a/tik_manager4/dcc/maya/extract/stl.py
+++ b/tik_manager4/dcc/maya/extract/stl.py
@@ -13,6 +13,7 @@ class Stl(ExtractCore):
 
     nice_name = "STL"
     color = (100, 200, 0)
+    bundled = True
 
     def __init__(self):
         super().__init__()
@@ -26,7 +27,6 @@ class Stl(ExtractCore):
         om.MGlobal.displayInfo("STL Extractor loaded")
 
         self._extension = ".stl"
-        self._bundled = True
         # we don't need to define category functions for STL
 
     @staticmethod

--- a/tik_manager4/dcc/maya/ingest/stl.py
+++ b/tik_manager4/dcc/maya/ingest/stl.py
@@ -13,6 +13,7 @@ class Stl(IngestCore):
 
     nice_name = "Ingest STL"
     valid_extensions = [".stl"]
+    bundled = True
 
     def __init__(self):
         super(Stl, self).__init__()
@@ -22,7 +23,6 @@ class Stl(IngestCore):
             except Exception as exc:
                 om.MGlobal.displayInfo("STL Import Plugin cannot be initialized")
                 raise exc
-        self._bundled = True
 
     def _bring_in_default(self):
         """Import STL File."""

--- a/tik_manager4/dcc/maya/utils.py
+++ b/tik_manager4/dcc/maya/utils.py
@@ -7,6 +7,7 @@ To prevent circular imports, these methods are collected here.
 
 from functools import wraps
 from maya import cmds
+from maya import mel
 
 
 def get_ranges():
@@ -38,6 +39,28 @@ def set_ranges(range_list):
         maxTime=range_list[2],
         animationEndTime=range_list[3],
     )
+
+def get_scene_fps():
+    """Return the current FPS value set by DCC. None if not supported."""
+    return mel.eval("currentTimeUnitToFPS")
+def set_scene_fps(fps_value):
+    """
+    Set the FPS value in DCC if supported.
+    Args:
+        fps_value: (integer) fps value
+
+    Returns: None
+
+    """
+    # maya is a bit weird with fps.
+    # there are number of predefined fps values. Some float, some int.
+    # Int ones don't accept float values and vice versa.
+    if int(fps_value) == fps_value:
+        fps_value = int(fps_value)
+    try:
+        mel.eval(f"currentUnit -time {fps_value}fps;")
+    except RuntimeError as exc:
+        raise RuntimeError("Invalid FPS value") from exc
 
 # decorator to keep the current selection
 def keepselection(func):

--- a/tik_manager4/dcc/maya/validate/forbidden_nodes.py
+++ b/tik_manager4/dcc/maya/validate/forbidden_nodes.py
@@ -1,7 +1,6 @@
 """Validation for unique names in Maya scene"""
 
 from maya import cmds
-from maya import mel
 from tik_manager4.dcc.validate_core import ValidateCore
 
 class ForbiddenNodes(ValidateCore):

--- a/tik_manager4/dcc/maya/validate/forbidden_nodes.py
+++ b/tik_manager4/dcc/maya/validate/forbidden_nodes.py
@@ -11,7 +11,7 @@ class ForbiddenNodes(ValidateCore):
     forbiddenNodeTypes = ["polyBlindData", "unknown", "blindDataTemplate"]
 
     def __init__(self):
-        super(ForbiddenNodes, self).__init__()
+        super().__init__()
         self.autofixable = True
         self.ignorable = True
         self.selectable = True

--- a/tik_manager4/dcc/maya/validate/fps.py
+++ b/tik_manager4/dcc/maya/validate/fps.py
@@ -1,0 +1,33 @@
+"""Simple validation to check the FPS."""
+
+from tik_manager4.dcc.maya import utils
+from tik_manager4.dcc.validate_core import ValidateCore
+
+class FPS(ValidateCore):
+    """Validate class for Maya"""
+
+    nice_name = "FPS"
+    def __init__(self):
+        super().__init__()
+        self.autofixable = True
+        self.ignorable = True
+        self.selectable = True
+        self._defined_fps : float
+        self._current_fps : float
+    def validate(self):
+        """Validate FPS"""
+        # check the fps value from the metadata
+        self._defined_fps = self.metadata.get_value("fps")
+        if not self._defined_fps:
+            self.ignored()
+            self.autofixable = False
+        self._current_fps = utils.get_scene_fps()
+        if self._current_fps != self._defined_fps:
+            self.failed(msg="FPS is not correct. Expected: {}, Found: {}".format(self._defined_fps, self._current_fps))
+        else:
+            self.passed()
+
+    def fix(self):
+        """Fix FPS"""
+        utils.set_scene_fps(self._defined_fps)
+        self.validate()

--- a/tik_manager4/dcc/validate_core.py
+++ b/tik_manager4/dcc/validate_core.py
@@ -2,6 +2,7 @@
 
 import importlib
 from pathlib import Path
+from tik_manager4.objects.metadata import Metadata
 
 
 class ValidateCore:
@@ -20,7 +21,9 @@ class ValidateCore:
         self.autofixable: bool = False
         self.selectable: bool = False
 
-        self.collection = []
+        self._metadata: Metadata
+
+        self.collection: list = []
 
         self._state: str = "idle"
         self._fail_message: str = ""
@@ -41,6 +44,14 @@ class ValidateCore:
     @property
     def fail_message(self):
         return self._fail_message
+
+    @property
+    def metadata(self):
+        return self._metadata
+
+    @metadata.setter
+    def metadata(self, metadata):
+        self._metadata = metadata
 
     def reset(self):
         """Reset the validation."""

--- a/tik_manager4/objects/metadata.py
+++ b/tik_manager4/objects/metadata.py
@@ -1,0 +1,55 @@
+"""Classes to hold and manage metadata."""
+import dataclasses
+from typing import Union
+
+
+@dataclasses.dataclass
+class Metaitem:
+    """Hold the value and overridden status of a property."""
+    value: Union[str, int, float, bool, list, dict, None]
+    overridden: bool
+
+class Metadata(dict):
+    """Metadata class."""
+    def __init__(self, data_dictionary):
+        """Initialize Metadata object.
+        Args:
+            data_dictionary (dict): The dictionary to initialize the metadata with.
+        """
+        super(Metadata, self).__init__(data_dictionary)
+
+        # create a Metaitem for each key in the data_dictionary
+        for key, val in data_dictionary.items():
+            self.add_item(key, val)
+
+    def add_item(self, key, value, overridden=False):
+        """Add an item to the metadata."""
+        self[key] = Metaitem(value, overridden=overridden)
+        return self[key]
+
+    def get_all_items(self):
+        """Return all items in the metadata."""
+        for key, val in self.items():
+            yield key, val.value
+
+    def get_value(self, key, fallback_value=None):
+        """Get the value of a key."""
+        if key in self:
+            return self[key].value
+        return fallback_value
+
+    def is_overridden(self, key):
+        """Check if a key is overridden."""
+        if key in self:
+            return self[key].overridden
+        return False
+
+    def override(self, data_dictionary):
+        """Override the metadata with a new dictionary."""
+        # clear metadata
+        for key, data in data_dictionary.items():
+            self[key] = Metaitem(data, overridden=True)
+
+    def exists(self, key):
+        """Check if the key exists."""
+        return key in self

--- a/tik_manager4/objects/publisher.py
+++ b/tik_manager4/objects/publisher.py
@@ -72,12 +72,10 @@ class Publisher:
         # collect the matching extracts and validations from the dcc_handler.
         for extract in extracts:
             if extract in list(self._dcc_handler.extracts.keys()):
-                self._resolved_extractors[extract] = self._dcc_handler.extracts[
-                    extract
-                ]()
-                self._resolved_extractors[
-                    extract
-                ].category = self._work_object.category  # define the category
+                self._resolved_extractors[extract] = self._dcc_handler.extracts[extract]()
+                # define the category
+                self._resolved_extractors[extract].category = self._work_object.category
+                self._resolved_extractors[extract].metadata = self._metadata
             else:
                 LOG.warning(
                     "Extract {0} defined in category settings but it is not available on {1}".format(
@@ -90,6 +88,7 @@ class Publisher:
                 self._resolved_validators[validation] = self._dcc_handler.validations[
                     validation
                 ]()
+                self._resolved_validators[validation].metadata = self._metadata
             else:
                 LOG.warning(
                     "Validation {0} defined in category settings but it is not available on {1}".format(
@@ -234,10 +233,15 @@ class Publisher:
         extract_object.extract_name = f"{self._work_object.name}_v{self._publish_version:03d}"  # define the extract name
         extract_object.extract()
 
+    # @property
+    # def metadata(self):
+    #     """Return the metadata as DICTIONARY."""
+    #     return dict(self._metadata.get_all_items())
+
     @property
     def metadata(self):
-        """Return the metadata as DICTIONARY."""
-        return dict(self._metadata.get_all_items())
+        """Return the metadata."""
+        return self._metadata
 
     @property
     def publish_version(self):

--- a/tik_manager4/objects/subproject.py
+++ b/tik_manager4/objects/subproject.py
@@ -6,66 +6,11 @@ import shutil
 
 from fnmatch import fnmatch
 from tik_manager4.core import filelog
+from tik_manager4.objects.metadata import Metadata
 from tik_manager4.objects.entity import Entity
 from tik_manager4.objects.task import Task
 
 LOG = filelog.Filelog(logname=__name__, filename="tik_manager4")
-
-
-class Metaitem(object):
-    """Hold the value and overridden status of a property."""
-
-    def __init__(self, value, overridden=False):
-        """Initialize Metaitem.
-        Args:
-            value (any): The value of the property.
-            overridden (bool): Whether the value is overridden or not.
-        """
-        self.value = value
-        self.overridden = overridden
-
-
-class Metadata(dict):
-    """Metadata class."""
-
-    def __init__(self, data_dictionary):
-        """Initialize Metadata object.
-        Args:
-            data_dictionary (dict): The dictionary to initialize the metadata with.
-        """
-        super(Metadata, self).__init__(data_dictionary)
-
-        # create a Metaitem for each key in the data_dictionary
-        for key, val in data_dictionary.items():
-            self.add_item(key, val)
-
-    def add_item(self, key, value, overridden=False):
-        """Add an item to the metadata."""
-        self[key] = Metaitem(value, overridden=overridden)
-        return self[key]
-
-    def get_all_items(self):
-        """Return all items in the metadata."""
-        for key, val in self.items():
-            yield key, val.value
-
-    def get_value(self, key, fallback_value=None):
-        """Get the value of a key."""
-        if key in self:
-            return self[key].value
-        return fallback_value
-
-    def is_overridden(self, key):
-        """Check if a key is overridden."""
-        if key in self:
-            return self[key].overridden
-        return False
-
-    def override(self, data_dictionary):
-        """Override the metadata with a new dictionary."""
-        # clear metadata
-        for key, data in data_dictionary.items():
-            self[key] = Metaitem(data, overridden=True)
 
 
 class Subproject(Entity):

--- a/tik_manager4/ui/dialog/publish_dialog.py
+++ b/tik_manager4/ui/dialog/publish_dialog.py
@@ -254,10 +254,7 @@ class PublishSceneDialog(QtWidgets.QDialog):
         # -------------------
         for _extractor_name, extractor in self.project.publisher.extractors.items():
             # get the metadata for the extractor
-            LOG.info(self.project.publisher.metadata)
-            extract_row = ExtractRow(
-                extract_object=extractor, override_data=self.project.publisher.metadata
-            )
+            extract_row = ExtractRow(extract_object=extractor)
             self.extracts_scroll_lay.addLayout(extract_row)
             self._extractor_widgets.append(extract_row)
         # -------------------
@@ -569,12 +566,10 @@ class ValidateRow(QtWidgets.QHBoxLayout):
 class ExtractRow(QtWidgets.QHBoxLayout):
     """Custom Layout for extract rows."""
 
-    def __init__(self, extract_object, override_data=None, *args, **kwargs):
+    def __init__(self, extract_object, *args, **kwargs):
         """Initialize the ExtractRow."""
         super(ExtractRow, self).__init__(*args, **kwargs)
         self.extract = extract_object
-        self.override_data = override_data  # this dict can be the entire metadata or just the picked settings.
-
         self.status_icon = None
         self.label = None
         self.settings_btn = None
@@ -620,11 +615,9 @@ class ExtractRow(QtWidgets.QHBoxLayout):
         header_layout.addLayout(self.collapsible_layout)
 
         self.settings_data = self.extract.global_settings
-        self.settings_data.update(self.extract.settings.get(self.extract.category, {}))
-        # self.settings_data = self.extract.settings.get(self.extract.category, None)
+        self.settings_data.update(self.extract.settings.get(self.extract.category, {}), add_missing_keys=True)
         if self.settings_data.properties:
             # update exposed setting defaults with the metadata (if exists)
-            self.settings_data.update(self.override_data or {})
             settings_ui = convert_to_ui_definition(self.settings_data)
             settings_formlayout = SettingsLayout(settings_ui, self.settings_data)
             self.collapsible_layout.contents_layout.addLayout(settings_formlayout)


### PR DESCRIPTION
metadata exposed to extract, ingest and validate.

- All global and category-defined extract settings default values are automatically getting corresponding metadata values (if keys exist)
- Validating the scene against any metadata is now possible. (see maya/validate/fps.py)
- metadata is getting passed to the ingest classes too but currently, there is no usage of it. But any ingest method can now manipulate the scene or settings of ingest using the relevant metadata.