### PR TITLE
Tik 99 enable deleting works and publishes

### DIFF
--- a/tests/maya/test_maya_project.py
+++ b/tests/maya/test_maya_project.py
@@ -126,9 +126,9 @@ class TestMayaProject():
         for count in range(1, 4):
             # RESOLVE
             project.publisher.resolve()
-            assert work_obj.path == project.publisher._work_object.path
-            assert work_obj.name == project.publisher._work_object.name
-            assert work_obj.id == project.publisher._work_object.id
+            assert work_obj.path == project.publisher.work_object.path
+            assert work_obj.name == project.publisher.work_object.name
+            assert work_obj.id == project.publisher.work_object.id
             assert project.publisher.publish_version == count
             # if category == "Model":
             #     assert project.publisher.extract_names == ["scene", "alembic"]

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -704,18 +704,15 @@ class TestProject:
             .categories["Model"]
         )
         works = model_category.scan_works()
-        target_work = list(works.keys())[0]
+        target_work = list(works.values())[0]
 
         # try to delete a work without permissions
         tik.user.set("Generic", password="1234")
-        assert model_category.delete_work(target_work) == -1
+        assert target_work.destroy() == -1
 
         tik.user.set("Admin", password="1234")
-        # try to delete a non existing work
-        assert model_category.delete_work("burhan_altintop") == -1
-
         # delete the work
-        assert model_category.delete_work(target_work) == 1
+        assert target_work.destroy() == 1
 
     def test_deleting_empty_task(self, project_manual_path, tik):
         self.test_creating_and_adding_new_tasks(project_manual_path, tik)

--- a/tik_manager4/dcc/main_core.py
+++ b/tik_manager4/dcc/main_core.py
@@ -58,7 +58,7 @@ class MainCore():
         Returns: (list) [<absolute range start>, <user range start>, <user range end>,
         <absolute range end>
         """
-        return (None, None, None, None)
+        pass
 
     @staticmethod
     def set_ranges(range_list):

--- a/tik_manager4/objects/category.py
+++ b/tik_manager4/objects/category.py
@@ -106,23 +106,6 @@ class Category(Entity):
         work.new_version(file_format=file_format, notes=notes, ignore_checks=ignore_checks)
         return work
 
-    def delete_work(self, work_path):
-        """Delete a work under the category."""
-        _work = self._works.get(Path(work_path), None)
-        if not _work:
-            LOG.warning(
-                "There is no work under this category with the name => %s" % work_path
-            )
-            return -1
-
-        # if not, check if the user is the owner of the work
-        if self.guard.user != _work.creator or not self.check_permissions(level=3):
-            LOG.warning("You do not have the permission to delete this work")
-            return -1
-        del self._works[work_path]
-        _work.delete()
-        return 1
-
     def get_relative_work_path(self):
         """Return the relative path of the category"""
         return Path(self.path, self.guard.dcc).as_posix()

--- a/tik_manager4/objects/entity.py
+++ b/tik_manager4/objects/entity.py
@@ -77,10 +77,10 @@ class Entity():
         return str(Path(self.guard.project_root, self.path, *args))
 
     def get_purgatory_project_path(self, *args):
-        return str(Path(self.guard.project_root, "__purgatory", self.path, *args))
+        return str(Path(self.guard.project_root, ".purgatory", self.path, *args))
 
     def get_purgatory_database_path(self, *args):
-        return str(Path(self.guard.project_root, "__purgatory", "tikDatabase",  self.path, *args))
+        return str(Path(self.guard.project_root, ".purgatory", "tikDatabase",  self.path, *args))
 
     @staticmethod
     def _open_folder(target):

--- a/tik_manager4/objects/publish.py
+++ b/tik_manager4/objects/publish.py
@@ -71,6 +71,11 @@ class Publish(Entity):
         """Return the state of the publish."""
         return self.work_object.state
 
+    @property
+    def parent_task(self):
+        """Return the parent task of the publish."""
+        return self.work_object.parent_task
+
     def reload(self):
         """Reload the publish object."""
         self.work_object.reload()

--- a/tik_manager4/objects/publisher.py
+++ b/tik_manager4/objects/publisher.py
@@ -45,6 +45,11 @@ class Publisher:
         """Return the extractors."""
         return self._resolved_extractors
 
+    @property
+    def work_object(self):
+        """Return the work object."""
+        return self._work_object
+
     def resolve(self):
         """Resolve the validations, extracts, variables, etc."""
         self._work_object, self._work_version = self._project_object.get_current_work()
@@ -102,7 +107,7 @@ class Publisher:
             self._work_object.publish.get_publish_data_folder()
         )
         self._abs_publish_scene_folder = (
-            self._work_object.publish.get_publish_scene_folder()
+            self._work_object.publish.get_publish_project_folder()
         )
         self._publish_version = latest_publish_version + 1
         self._publish_file_name = (

--- a/tik_manager4/objects/subproject.py
+++ b/tik_manager4/objects/subproject.py
@@ -325,12 +325,9 @@ class Subproject(Entity):
                     task_name
                 )
             )
-            from tik_manager4.core import io
 
             Path(self.get_purgatory_database_path(task.file_name)).mkdir(parents=True, exist_ok=True)
-            # io.IO().folder_check(self.get_purgatory_database_path(task.file_name))
             Path(self.get_purgatory_project_path()).mkdir(parents=True, exist_ok=True)
-            # io.IO().folder_check(self.get_purgatory_project_path())
             shutil.move(
                 self.get_abs_database_path(task.file_name),
                 self.get_purgatory_database_path(task.file_name),

--- a/tik_manager4/objects/work.py
+++ b/tik_manager4/objects/work.py
@@ -120,7 +120,7 @@ class Work(Settings, Entity):
 
     def reload(self):
         """Reload from file"""
-        self.__init__(self.settings_file)
+        self.__init__(self.settings_file, name=self._name, path=self._relative_path, parent_task=self._parent_task)
 
     def omit(self):
         """Omit the work."""

--- a/tik_manager4/ui/dialog/preview_dialog.py
+++ b/tik_manager4/ui/dialog/preview_dialog.py
@@ -14,7 +14,13 @@ class PreviewDialog(QtWidgets.QDialog):
         self.version = version
         self.work = work_object
         self.resolution = resolution or self.work.guard.project_settings.get_property("resolution", [1920, 1080])
-        range_start, _urs, _ure, range_end = self.work._dcc_handler.get_ranges()
+        raw_ranges = self.work._dcc_handler.get_ranges()
+        if raw_ranges:
+            range_start = raw_ranges[0]
+            range_end = raw_ranges[-1]
+        else:
+            range_start = 1001
+            range_end = 1100
         _range = range or [range_start, range_end]
         self.range = [_range[0] or range_start, _range[1] or range_end]
         self.setWindowTitle("Create Preview")

--- a/tik_manager4/ui/dialog/publish_dialog.py
+++ b/tik_manager4/ui/dialog/publish_dialog.py
@@ -109,7 +109,7 @@ class PublishSceneDialog(QtWidgets.QDialog):
 
     def check_eligibility(self):
         """Checks if the current scene is eligible for publishing."""
-        if not self.project.publisher._work_object:
+        if not self.project.publisher.work_object:
             self.feedback.pop_info(
                 title="Non-valid Scene",
                 text="Current Scene does not belong to a 'Work' in this project. Please save scene as a 'Work' before publishing or switch to the correct project.",

--- a/tik_manager4/ui/dialog/work_dialog.py
+++ b/tik_manager4/ui/dialog/work_dialog.py
@@ -367,9 +367,12 @@ class NewVersionDialog(QtWidgets.QDialog):
         # align texts in combo to the right
         self.format_combo.setItemDelegate(QtWidgets.QStyledItemDelegate())
         # try to get the format from the last version and set it as current
-        _format = self.work_object.versions[-1].get(
-            "file_format", self.work_object._dcc_handler.formats[0]
-        )
+        if self.work_object.versions:
+            _format = self.work_object.versions[-1].get(
+                "file_format", self.work_object._dcc_handler.formats[0]
+            )
+        else:
+            _format = self.work_object._dcc_handler.formats[0]
         self.format_combo.setCurrentText(_format)
         self.on_format_changed(_format)  # initialize the name label with the format
 

--- a/tik_manager4/ui/mcv/category_mcv.py
+++ b/tik_manager4/ui/mcv/category_mcv.py
@@ -400,9 +400,51 @@ class TikCategoryView(QtWidgets.QTreeView):
 
     def delete_item(self, item):
         """Deletes the given item"""
-        print("Method not implemented")
-        print(item)
-        # TODO
+
+        # lets make pre-check for permissions:
+        state, msg = item.tik_obj.check_destroy_permissions()
+        if not state:
+            self.feedback.pop_info(title="Permission error", text=msg, critical=True)
+            return
+
+        if item.tik_obj.object_type == "work":
+            are_you_sure = self.feedback.pop_question(
+                title="Are you sure?",
+                text=f"You are about to delete '{item.tik_obj.name}' completely.\n\n"
+                     "This will delete ALL VERSIONS and ALL PUBLISHES of this work.\n\n"
+                     "This action cannot be undone.\n"
+                     "Are you sure you want to continue?",
+                buttons=["yes", "cancel"]
+            )
+            if are_you_sure == "cancel":
+                return
+            # double check if there is a publish under this work
+            if item.tik_obj.publish.versions:
+                are_you_sure = self.feedback.pop_question(
+                    title="Are you REALLY sure?",
+                    text="There are published versions under this work.\n\n"
+                         "ALL PUBLISHES and ALL WORK VERSIONS will be deleted.\n\n"
+                         "This action cannot be undone.\n"
+                         "Are you REALLY sure you want to continue?",
+                    buttons=["yes", "cancel"]
+                )
+                if are_you_sure == "cancel":
+                    return
+        elif item.tik_obj.object_type == "publish":
+            are_you_sure = self.feedback.pop_question(
+                title="Are you sure?",
+                text=f"You are about to delete '{item.tik_obj.name}' completely.\n\n"
+                     "This will delete ALL VERSIONS of this publish.\n\n"
+                     "This action cannot be undone.\n"
+                     "Are you sure you want to continue?",
+                buttons=["yes", "cancel"]
+            )
+            if are_you_sure == "cancel":
+                return
+
+        item.tik_obj.destroy()
+        # remove the item from the model
+        self.model.removeRow(item.row())
 
 
 

--- a/tik_manager4/ui/mcv/version_mcv.py
+++ b/tik_manager4/ui/mcv/version_mcv.py
@@ -159,7 +159,7 @@ class TikVersionLayout(QtWidgets.QVBoxLayout):
             return
 
         if self.base.object_type == "publish":
-            work_obj = self.base._work_object
+            work_obj = self.base.work_object
         else:
             work_obj = self.base
 
@@ -419,15 +419,21 @@ class TikVersionLayout(QtWidgets.QVBoxLayout):
             )
             return
         _version = self.get_selected_version()
+
+        state, msg = self.base.check_delete_version_permissions(_version)
+        if state != 1:
+            self.feedback.pop_info(
+                title="Permission Error",
+                text=msg,
+                critical=True,
+            )
+            return
+
         if self.base.object_type == "work":
-            # print("Deleting work version")
-            # print(_version)
-            # _obj = self.base.get_version(_version)
-            # print(_obj)
             _name = self.base.get_version(_version).get("scene_path", "")
             are_you_sure = self.feedback.pop_question(
                 title="Delete Work Version",
-                text="You are about to delete the work version:\n\n"
+                text="You are about to delete a work version:\n\n"
                      f"{_name}\n\n"
                      "This action cannot be undone.\n"
                      "Do you want to continue?",
@@ -435,16 +441,28 @@ class TikVersionLayout(QtWidgets.QVBoxLayout):
                 )
             if are_you_sure == "cancel":
                 return
-            self.base.delete_version(_version)
-            # repopulate the combo box
-            self.populate_versions(self.base._versions)
-        # self.base.delete_version(_version)
+        elif self.base.object_type == "publish":
+            _name = self.base.get_version(_version).get("name", "")
+            are_you_sure = self.feedback.pop_question(
+                title="Delete Publish Version",
+                text="You are about to delete a PUBLISH version:\n\n"
+                     f"{_name}\n\n"
+                     "This action cannot be undone.\n"
+                     "Do you want to continue?",
+                buttons=["yes", "cancel"]
+                )
+            if are_you_sure == "cancel":
+                return
+
+        self.base.delete_version(_version)
+        # repopulate the combo box
+        self.populate_versions(self.base.versions)
 
     def refresh(self):
         """Refresh the version dropdown."""
         if self.base:
             self.base.reload()
-            self.populate_versions(self.base._versions)
+            self.populate_versions(self.base.versions)
         else:
             self.version_combo.clear()
             self.notes_editor.clear()

--- a/tik_manager4/ui/mcv/version_mcv.py
+++ b/tik_manager4/ui/mcv/version_mcv.py
@@ -105,6 +105,9 @@ class TikVersionLayout(QtWidgets.QVBoxLayout):
         self.load_btn.clicked.connect(self.on_load)
         self.reference_btn.clicked.connect(self.on_reference)
 
+        self.version_combo.setContextMenuPolicy(QtCore.Qt.CustomContextMenu)
+        self.version_combo.customContextMenuRequested.connect(self.right_click_menu)
+
     def on_import(self):
         """Import the current version."""
         if not self.base:
@@ -317,7 +320,10 @@ class TikVersionLayout(QtWidgets.QVBoxLayout):
         """When the version dropdown is changed, update the notes and thumbnail."""
         self.element_combo.blockSignals(True)
         self.ingest_with_combo.blockSignals(True)
-        version_number = int(self.version_combo.currentText())
+        version_text = self.version_combo.currentText()
+        if not version_text:
+            return
+        version_number = int(version_text)
         _index = self.version_combo.currentIndex()
         # check if the _index is the latest in combo box
         if _index == self.version_combo.count() - 1:
@@ -403,6 +409,37 @@ class TikVersionLayout(QtWidgets.QVBoxLayout):
         else:
             return None
 
+    def delete_version(self):
+        """Delete the selected Work or Publish version."""
+        if not self.base:
+            self.feedback.pop_info(
+                title="No work or publish selected.",
+                text="Please select a work or publish to delete.",
+                critical=True,
+            )
+            return
+        _version = self.get_selected_version()
+        if self.base.object_type == "work":
+            # print("Deleting work version")
+            # print(_version)
+            # _obj = self.base.get_version(_version)
+            # print(_obj)
+            _name = self.base.get_version(_version).get("scene_path", "")
+            are_you_sure = self.feedback.pop_question(
+                title="Delete Work Version",
+                text="You are about to delete the work version:\n\n"
+                     f"{_name}\n\n"
+                     "This action cannot be undone.\n"
+                     "Do you want to continue?",
+                buttons=["yes", "cancel"]
+                )
+            if are_you_sure == "cancel":
+                return
+            self.base.delete_version(_version)
+            # repopulate the combo box
+            self.populate_versions(self.base._versions)
+        # self.base.delete_version(_version)
+
     def refresh(self):
         """Refresh the version dropdown."""
         if self.base:
@@ -412,6 +449,19 @@ class TikVersionLayout(QtWidgets.QVBoxLayout):
             self.version_combo.clear()
             self.notes_editor.clear()
             self.thumbnail.clear()
+
+    def right_click_menu(self, position):
+        """Right click menu for the version dropdown."""
+
+        right_click_menu = QtWidgets.QMenu()
+        right_click_menu.setStyleSheet(self.parent.styleSheet())  # Add this line
+
+        delete_version_action = QtWidgets.QAction(self.tr("Delete Version"), self)
+        right_click_menu.addAction(delete_version_action)
+        delete_version_action.triggered.connect(self.delete_version)
+
+        right_click_menu.exec_((QtGui.QCursor.pos()))
+
 
 
 class ImageWidget(QtWidgets.QLabel):


### PR DESCRIPTION
- deleting functionalities for works, publishes and their versions added
- Deleted items goes to .purgatory folder under the project root.
- Items in the purgatory needs be restored manually if required. Currently there is no methodology for purgatory management.
- There is no further protection for the purgatory. If an item with same path deleted again, it wil write over the purgatory item.
