### PR TITLE
hotfix - pyside6 / pyqt6 compatibility fix

### DIFF
--- a/tik_manager4/ui/dialog/settings_dialog.py
+++ b/tik_manager4/ui/dialog/settings_dialog.py
@@ -92,10 +92,10 @@ class SettingsDialog(QtWidgets.QDialog):
 
         tik_button_box = TikButtonBox(parent=self)
         self.layouts.buttons_layout.addWidget(tik_button_box)
-        self.apply_button = tik_button_box.addButton("Apply", tik_button_box.ApplyRole)
+        self.apply_button = tik_button_box.addButton("Apply", QtWidgets.QDialogButtonBox.ApplyRole)
         self.apply_button.setEnabled(False)
-        cancel_button = tik_button_box.addButton("Cancel", tik_button_box.RejectRole)
-        ok_button = tik_button_box.addButton("Ok", tik_button_box.AcceptRole)
+        cancel_button = tik_button_box.addButton("Cancel", QtWidgets.QDialogButtonBox.RejectRole)
+        ok_button = tik_button_box.addButton("Ok", QtWidgets.QDialogButtonBox.AcceptRole)
 
         # SIGNALS
         self.apply_button.clicked.connect(self.apply_settings)
@@ -1014,9 +1014,9 @@ class CategoryDefinitions(QtWidgets.QWidget):
         horizontal_layout.addWidget(name_line_edit)
         # create a button box
         button_box = TikButtonBox()
-        add_category_pb = button_box.addButton("Add", button_box.AcceptRole)
+        add_category_pb = button_box.addButton("Add", QtWidgets.QDialogButtonBox.AcceptRole)
         name_line_edit.set_connected_widgets(add_category_pb)
-        _cancel_pb = button_box.addButton("Cancel", button_box.RejectRole)
+        _cancel_pb = button_box.addButton("Cancel", QtWidgets.QDialogButtonBox.RejectRole)
         dialog_layout.addWidget(button_box)
         # if user clicks ok return the selected items
         # button_box.accepted.connect(add_category_dialog.accept)

--- a/tik_manager4/ui/widgets/common.py
+++ b/tik_manager4/ui/widgets/common.py
@@ -125,9 +125,10 @@ class TikButton(QtWidgets.QPushButton, StyleEditor):
         text_color="#b1b1b1",
         border_color="#1e1e1e",
         background_color="#404040",
+        *args,
         **kwargs,
     ):
-        super(TikButton, self).__init__(**kwargs)
+        super().__init__()
         # make sure the button has a font defined for different OS scales
         self.setText(text)
         self.text_color = text_color

--- a/tik_manager4/ui/widgets/switch_tree.py
+++ b/tik_manager4/ui/widgets/switch_tree.py
@@ -24,8 +24,8 @@ class SwitchTreeItem(QtWidgets.QTreeWidgetItem):
     @content.setter
     def content(self, widget):
         """Set the content widget"""
-        # validata if the widget is a QWidget
-        if not isinstance(widget, QtWidgets.QWidget):
+        # validata if the widget is a QWidget or None
+        if widget is not None and not isinstance(widget, QtWidgets.QWidget):
             raise ValueError("The content must be a QWidget")
         self._content = widget
 


### PR DESCRIPTION
- pyside6 pyqt6 is not accepting the instanced variables when defining the button roles.

```
test = QtWidgets.QDialogButtonBox()
# this is not working on pyside6 anymore
test.addButton("Apply", test .ApplyRole)

# it needs to be set like this:
test.addButton("Apply", QtWidgets.QDialogButtonBox.ApplyRole)
```