### PR TITLE
hotfix for importomatic name

### DIFF
--- a/tik_manager4/dcc/katana/ingest/importomatic.py
+++ b/tik_manager4/dcc/katana/ingest/importomatic.py
@@ -33,22 +33,19 @@ class Importomatic(IngestCore):
 
         # Create alembic group node
         abc_grp = NodegraphAPI.CreateNode('Group', NodegraphAPI.GetRootNode())
-        abc_grp.setName('abc_test_group')
+        # this is a quick and dirty way to identify the group node name.
+        # TODO: Find a better way to identify the group node name.
+        group_node_name = (Path(self.ingest_path).name).split("_", 1)[-1]
+        abc_grp.setName(group_node_name)
         abc_grp.setType('Alembic')
         abc_grp.addOutputPort('out')
         abc_grp_port = abc_grp.getReturnPort('out')
 
         # Build group node params for importomatic
         assetinfo_page = abc_grp.getParameters().createChildGroup('assetInfo')
-        '''
-        Untested, but seem to be used by the Add Alembic context
-        name_page = assetinfo_page.createChildGroup(abc_grp.getName())
-        name_page.createChildString('_ignore', 'False')
-        name_page.createChildString('_sgPath', '/{0}'.format(abc_grp.getName()))
-        '''
 
         abc_in_node = NodegraphAPI.CreateNode('Alembic_In', abc_grp)
-        abc_in_node.setName('abc_test')
+        abc_in_node.setName(group_node_name)
         abc_in_node.getParameter('abcAsset').setValue(self.ingest_path, 0)
         abc_node_port = abc_in_node.getOutputPort('out')
 


### PR DESCRIPTION
Fix for Importomatic group name when importing caches into Katana.