### PR TITLE
nuke integration tookbar code for menu.py

### DIFF
--- a/tik_manager4/dcc/nuke/setup/how-to-install.txt
+++ b/tik_manager4/dcc/nuke/setup/how-to-install.txt
@@ -21,9 +21,9 @@ if not tik_path in sys.path:
 # Tik Manager 4 [Start]
 toolbar = nuke.menu('Nodes')
 smMenu = toolbar.addMenu('SceneManager', icon='tik4_main_ui.png')
-smMenu.addCommand('Main UI', 'from tik_manager4.ui import main as tik4_main\ntik4_main.launch(dcc='Nuke')', icon='tik4_main_ui.png')
-smMenu.addCommand('New Version', 'from tik_manager4.ui import main\ntui = main.launch(dcc='Nuke', dont_show=True)\ntui.on_new_version()', icon='tik4_new_version.png')
-smMenu.addCommand('Publish', 'from tik_manager4.ui import main\ntui = main.launch(dcc='Nuke', dont_show=True)\ntui.on_publish_scene()', icon='tik4_publish.png')
+smMenu.addCommand('Main UI', "from tik_manager4.ui import main\ntui = main.launch(dcc='Nuke')", icon='tik4_main_ui.png')
+smMenu.addCommand('New Version', "from tik_manager4.ui import main\ntui = main.launch(dcc='Nuke', dont_show=True)\ntui.on_new_version()", icon='tik4_new_version.png')
+smMenu.addCommand('Publish', "from tik_manager4.ui import main\ntui = main.launch(dcc='Nuke', dont_show=True)\ntui.on_publish_scene()", icon='tik4_publish.png')
 # Tik Manager 4 [End]
 
 - Restart Nuke


### PR DESCRIPTION
threw string 1 syntax error in nuke due to single quotes wrapping single quotes

changed module directory, same as the 'New Version' and 'Publish' buttons