### PR TITLE
metadata can be read and overridden directly from tasks. Task creatio…

### DIFF
--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -261,7 +261,9 @@ class TestProject:
 
     def test_delete_sub_project(self, project_manual_path, tik):
         """Test deleting sub-projects."""
-        sub, task, work = self._create_a_subproject_task_and_work(project_manual_path, tik)
+        sub, task, work = self._create_a_subproject_task_and_work(
+            project_manual_path, tik
+        )
 
         soft_sub = sub.add_sub_project("soft_sub")
 
@@ -288,7 +290,6 @@ class TestProject:
 
         # delete with path
         assert tik.project.delete_sub_project(path=sub.path) == 1
-
 
     # def test_deleting_sub_projects(self, project_manual_path, tik):
     #     """Tests deleting the sub-projects"""
@@ -334,7 +335,6 @@ class TestProject:
         assert tik.project.find_sub_by_id(sub.id) == sub
         assert sub.find_sub_by_id(sub.id) == sub
         assert tik.project.find_sub_by_id(-999) == -1
-
 
     def test_find_subs_by_wildcard(self, project_manual_path, tik):
         test_project_path = self.test_create_a_shot_asset_project_structure(
@@ -910,22 +910,20 @@ class TestProject:
             "mocked_dcc_version",
         )
 
-        # mock the sub's meta data to override the dcc version which will be compared against.
-        monkeypatch.setattr(
-            sub._metadata, "get_value", lambda _key, _: "monkeypatched_version"
-        )
+        #monkeypatch all instances of the metadata.get_value method to return a value for testing
+        def mock_get_value(*args, **kwargs):
+            return "monkeypatched_version"
+
+        import tik_manager4.objects.metadata
+        monkeypatch.setattr(tik_manager4.objects.metadata.Metadata, "get_value", mock_get_value)
+
+
         assert work_object.check_dcc_version_mismatch() == (
             "monkeypatched_version",
             "mocked_dcc_version",
         )
 
-        # in the case of where the parent_task doesn't have a parent sub
-        # and there is no parent task at all:
-        work_object._parent_task._parent_sub = None
-        assert work_object.check_dcc_version_mismatch() == (
-            "this_mock_should_fail",
-            "mocked_dcc_version",
-        )
+        # in the case of where ther is no parent task at all:
         work_object._parent_task = None
         assert work_object.check_dcc_version_mismatch() == (
             "this_mock_should_fail",

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -204,10 +204,12 @@ def test_getting_metadata(tik, monkeypatch):
 
     assert tik.project.get_metadata(tasks["main"]) == {}
 
-    # mock the metadata
+    # # mock the metadata
     monkeypatch.setattr(
-        tik.project._metadata, "get_value", lambda _key, _: "monkeypatched_version"
+        tasks["main"].metadata, "get_value", lambda _key, _: "monkeypatched_version"
     )
+
+    tik.project._metadata.add_item("key", "monkeypatched_version")
 
     assert tik.project.get_metadata(tasks["main"], "key") == "monkeypatched_version"
     monkeypatch.undo()

--- a/tik_manager4/objects/category.py
+++ b/tik_manager4/objects/category.py
@@ -245,13 +245,3 @@ class Category(Entity):
             str: Constructed name.
         """
         return "{0}_{1}_{2}".format(self.parent_task.name, self.name, name)
-
-    # def get_metadata(self, parent_task, key=None):
-    #     """Convenience method to get the metadata for work and category objects."""
-    #     # if this is a subproject, get the metadata directly from the attribute.
-    #     parent_sub = parent_task.parent_sub
-    #     if not parent_sub:
-    #         return None
-    #     if key:
-    #         return parent_sub.metadata.get_value(key, None)
-    #     return parent_sub.metadata

--- a/tik_manager4/objects/entity.py
+++ b/tik_manager4/objects/entity.py
@@ -164,9 +164,13 @@ class Entity:
 
         if not parent_task:
             return None
-        parent_sub = parent_task.parent_sub
-        if not parent_sub:
-            return None
         if key:
-            return parent_sub.metadata.get_value(key, None)
-        return parent_sub.metadata
+            return parent_task.metadata.get_value(key, None)
+        return parent_task.metadata
+
+        # parent_sub = parent_task.parent_sub
+        # if not parent_sub:
+        #     return None
+        # if key:
+        #     return parent_sub.metadata.get_value(key, None)
+        # return parent_sub.metadata

--- a/tik_manager4/objects/guard.py
+++ b/tik_manager4/objects/guard.py
@@ -12,6 +12,7 @@ class Guard:
     _last_warning = None
     _last_info = None
     _category_definitions = None
+    _metadata_definitions = None
     _asset_categories = []
     _shot_categories = []
     _null_categories = []
@@ -154,3 +155,17 @@ class Guard:
     def category_definitions(self):
         """Return the category definitions."""
         return self._category_definitions
+
+    @classmethod
+    def set_metadata_definitions(cls, definitions):
+        """Set the metadata definitions.
+
+        Args:
+            definitions (Settings): The metadata definitions.
+        """
+        cls._metadata_definitions = definitions
+
+    @property
+    def metadata_definitions(self):
+        """Return the metadata definitions."""
+        return self._metadata_definitions

--- a/tik_manager4/objects/metadata.py
+++ b/tik_manager4/objects/metadata.py
@@ -76,6 +76,38 @@ class Metadata(dict):
         for key, data in data_dictionary.items():
             self[key] = Metaitem(data, overridden=True)
 
+    def copy(self):
+        """Return a copy of the metadata."""
+        return Metadata(dict(self.get_all_items()))
+
     def exists(self, key):
         """Check if the key exists."""
         return key in self
+
+class FilteredData(dict):
+    """Class to filter the overridden and new data."""
+    def __init__(self, **kwargs):
+        super(FilteredData, self).__init__()
+        self.update(kwargs)
+
+    def update_overridden_data(self, settings_data):
+        for key, value in settings_data.get_data().items():
+            # if it starts __override, skip
+            if key.startswith("__override"):
+                continue
+            # if the key has a __override key, check if it is True
+            _override_key = "__override_{}".format(key)
+            if _override_key not in list(settings_data.get_data().keys()):
+                self[key] = value
+            else:
+                if settings_data.get_property(_override_key):
+                    self[key] = value
+
+    def update_new_data(self, settings_data):
+        for key, value in settings_data.get_data().items():
+            if key.startswith("__new"):
+                continue
+            # if the new checked box is checked, add the key to the filtered_data
+            _new_key = "__new_{}".format(key)
+            if settings_data.get_property(_new_key):
+                self[key] = value

--- a/tik_manager4/objects/project.py
+++ b/tik_manager4/objects/project.py
@@ -123,6 +123,8 @@ class Project(Subproject):
             self.guard.commons.metadata.settings_file
         )
 
+        self.guard.set_metadata_definitions(self.metadata_definitions)
+
     def delete_sub_project(self, uid=None, path=None):
         """Delete a subproject and all its children.
 
@@ -216,7 +218,7 @@ class Project(Subproject):
         self.save_structure()
         return 1
 
-    def create_task(self, name, categories=None, parent_uid=None, parent_path=None):
+    def create_task(self, name, categories=None, parent_uid=None, parent_path=None, metadata_overrides=None):
         """Create a task and stores it in persistent database.
 
         Either parent_uid or parent_path must be provided.
@@ -230,6 +232,7 @@ class Project(Subproject):
         Returns:
             int: 1 if successful, -1 otherwise.
         """
+        metadata_overrides = metadata_overrides or {}
         state = self.check_permissions(level=2)
         if state != 1:
             return -1
@@ -237,7 +240,7 @@ class Project(Subproject):
             self.log.error("Requires at least a parent uid or parent path ")
             return -1
         parent_sub = self.__validate_and_get_sub(parent_uid, parent_path)
-        task = parent_sub.add_task(name, categories=categories)
+        task = parent_sub.add_task(name, categories=categories, metadata_overrides=metadata_overrides)
         return task
 
     def __validate_and_get_sub(self, parent_uid, parent_path):

--- a/tik_manager4/objects/publisher.py
+++ b/tik_manager4/objects/publisher.py
@@ -76,7 +76,8 @@ class Publisher:
         self._task_object = self._project_object.find_task_by_id(
             self._work_object.task_id
         )
-        self._metadata = self._task_object.parent_sub.metadata
+        # self._metadata = self._task_object.parent_sub.metadata
+        self._metadata = self._task_object.metadata
 
         _category_definitons = self._work_object.guard.category_definitions
         extracts = _category_definitons.properties.get(

--- a/tik_manager4/objects/subproject.py
+++ b/tik_manager4/objects/subproject.py
@@ -268,7 +268,7 @@ class Subproject(Entity):
 
         return self._tasks
 
-    def add_task(self, name, categories, task_type=None):
+    def add_task(self, name, categories, task_type=None, metadata_overrides=None):
         """
         Add a task to the subproject.
 
@@ -282,6 +282,9 @@ class Subproject(Entity):
             Task or int: The created task object if successful, -1 otherwise.
 
         """
+
+        metadata_overrides = metadata_overrides or {}
+
         # inherit the task type from the parent subproject 'mode' if not specified
         task_type = task_type or self.metadata.get_value("mode", None)
         file_name = "{0}.ttask".format(name)
@@ -311,6 +314,7 @@ class Subproject(Entity):
         _task.add_property("categories", categories)
         _task.add_property("path", self.path)
         _task.add_property("file_name", file_name)
+        _task.add_property("metadata_overrides", metadata_overrides)
         _task.apply_settings()
         self._tasks[name] = _task
         return _task

--- a/tik_manager4/objects/task.py
+++ b/tik_manager4/objects/task.py
@@ -4,6 +4,7 @@
 
 from pathlib import Path
 import shutil
+from tik_manager4.objects.metadata import Metadata
 from tik_manager4.core.settings import Settings
 from tik_manager4.objects.category import Category
 from tik_manager4.objects.entity import Entity
@@ -60,6 +61,8 @@ class Task(Settings, Entity):
 
         self._parent_sub = parent_sub
 
+        self._metadata_overrides = self.get_property("metadata_overrides") or {}
+
     @property
     def file_name(self):
         """File Name of the task settings file."""
@@ -94,6 +97,15 @@ class Task(Settings, Entity):
     def parent_sub(self):
         """Parent sub of the task."""
         return self._parent_sub
+
+    @property
+    def metadata(self):
+        """Metadata of the task."""
+        if self._parent_sub:
+            _metadata = self._parent_sub.metadata.copy()
+            _metadata.override(self._metadata_overrides)
+            return _metadata
+        return Metadata(self._metadata_overrides)
 
     def build_categories(self, category_list):
         """Create category objects.
@@ -141,7 +153,7 @@ class Task(Settings, Entity):
         self.apply_settings()
         return self._categories[category]
 
-    def edit(self, name=None, task_type=None, categories=None):
+    def edit(self, name=None, task_type=None, categories=None, metadata_overrides=None):
         """Edit the task.
 
         Edits the given arguments of the task and applies the settings.
@@ -188,6 +200,9 @@ class Task(Settings, Entity):
                     )
             self._categories = self.build_categories(categories)
             self.edit_property("categories", list(categories))
+        if metadata_overrides is not None: # explicitly check for None
+            self._metadata_overrides = metadata_overrides
+            self.edit_property("metadata_overrides", metadata_overrides)
         self.apply_settings()
         return 1
 

--- a/tik_manager4/objects/work.py
+++ b/tik_manager4/objects/work.py
@@ -777,15 +777,3 @@ class Work(Settings, Entity):
         if defined_dcc_version in ["NA", "", current_dcc]:
             return False
         return defined_dcc_version, current_dcc
-
-    # def get_metadata(self, parent_task, key=None):
-    #     """Convenience method to get the metadata for work and category objects."""
-    #     # if this is a subproject, get the metadata directly from the attribute.
-    #     if not parent_task:
-    #         return None
-    #     parent_sub = parent_task.parent_sub
-    #     if not parent_sub:
-    #         return None
-    #     if key:
-    #         return parent_sub.metadata.get_value(key, None)
-    #     return parent_sub.metadata

--- a/tik_manager4/ui/dialog/data_containers.py
+++ b/tik_manager4/ui/dialog/data_containers.py
@@ -16,4 +16,3 @@ class MainLayout:
     left_layout: QtWidgets.QVBoxLayout = None
     right_layout: QtWidgets.QVBoxLayout = None
     buttons_layout: QtWidgets.QHBoxLayout = None
-

--- a/tik_manager4/ui/dialog/subproject_dialog.py
+++ b/tik_manager4/ui/dialog/subproject_dialog.py
@@ -1,5 +1,6 @@
 """Dialog for new subproject creation."""
 
+from tik_manager4.objects.metadata import FilteredData
 from tik_manager4.core.settings import Settings
 from tik_manager4.ui.Qt import QtWidgets
 from tik_manager4.ui.dialog.feedback import Feedback
@@ -87,7 +88,6 @@ class EditSubprojectDialog(QtWidgets.QDialog):
         self.secondary_content = tik_manager4.ui.layouts.settings_layout.SettingsLayout(
             self.secondary_definition, self.secondary_data, parent=self
         )
-        self.secondary_definition
         self.secondary_layout.contents_layout.addLayout(self.secondary_content)
         self.tertiary_content = tik_manager4.ui.layouts.settings_layout.SettingsLayout(
             self.tertiary_definition, self.tertiary_data, parent=self
@@ -296,32 +296,32 @@ class NewSubprojectDialog(EditSubprojectDialog):
         return self._new_subproject
 
 
-class FilteredData(dict):
-    def __init__(self, **kwargs):
-        super(FilteredData, self).__init__()
-        self.update(kwargs)
-
-    def update_overridden_data(self, settings_data):
-        for key, value in settings_data.get_data().items():
-            # if it starts __override, skip
-            if key.startswith("__override"):
-                continue
-            # if the key has a __override key, check if it is True
-            _override_key = "__override_{}".format(key)
-            if _override_key not in list(settings_data.get_data().keys()):
-                self[key] = value
-            else:
-                if settings_data.get_property(_override_key):
-                    self[key] = value
-
-    def update_new_data(self, settings_data):
-        for key, value in settings_data.get_data().items():
-            if key.startswith("__new"):
-                continue
-            # if the new checked box is checked, add the key to the filtered_data
-            _new_key = "__new_{}".format(key)
-            if settings_data.get_property(_new_key):
-                self[key] = value
+# class FilteredData(dict):
+#     def __init__(self, **kwargs):
+#         super(FilteredData, self).__init__()
+#         self.update(kwargs)
+#
+#     def update_overridden_data(self, settings_data):
+#         for key, value in settings_data.get_data().items():
+#             # if it starts __override, skip
+#             if key.startswith("__override"):
+#                 continue
+#             # if the key has a __override key, check if it is True
+#             _override_key = "__override_{}".format(key)
+#             if _override_key not in list(settings_data.get_data().keys()):
+#                 self[key] = value
+#             else:
+#                 if settings_data.get_property(_override_key):
+#                     self[key] = value
+#
+#     def update_new_data(self, settings_data):
+#         for key, value in settings_data.get_data().items():
+#             if key.startswith("__new"):
+#                 continue
+#             # if the new checked box is checked, add the key to the filtered_data
+#             _new_key = "__new_{}".format(key)
+#             if settings_data.get_property(_new_key):
+#                 self[key] = value
 
 
 class SelectSubprojectDialog(QtWidgets.QDialog):

--- a/tik_manager4/ui/dialog/task_dialog.py
+++ b/tik_manager4/ui/dialog/task_dialog.py
@@ -1,9 +1,13 @@
 """Dialog for new subproject creation."""
+
 import sys
+
+from tik_manager4.objects.metadata import FilteredData
 from tik_manager4.core.settings import Settings
 from tik_manager4.ui.Qt import QtWidgets
 from tik_manager4.ui.dialog import feedback
 from tik_manager4.ui.widgets.common import TikButtonBox
+from tik_manager4.ui.layouts.collapsible_layout import CollapsibleLayout
 
 import tik_manager4.ui.layouts.settings_layout
 
@@ -11,156 +15,34 @@ if __name__ == "__main__":
     app = QtWidgets.QApplication(sys.argv)
 
 
-class EditTask(QtWidgets.QDialog):
-    def __init__(self, task_object, parent_sub=None, parent=None, *args, **kwargs):
-        """Dialog for task editing."""
-        super(EditTask, self).__init__(parent=parent, *args, **kwargs)
-        self.task_object = task_object
-        self.feedback = feedback.Feedback(parent=self)
-        self._parent_sub = parent_sub or task_object.parent_sub
-        self.parent = parent
-        self.setWindowTitle("Edit Task")
-        self.setFixedSize(600, 400)
-        self.setModal(True)
+class TaskDialog(QtWidgets.QDialog):
+    """Shared dialog for task creation and editing."""
 
-        self.category_type_dictionary = self._categorize_category_definitions()
-
-        self.ui_definition = self.define_ui_dictionary()
-        self._init_ui()
-
-        self._new_task = None
-
-    def _categorize_category_definitions(self):
-        """Categorize category definitions."""
-        _items = self._parent_sub.guard.category_definitions.get_data().items()
-        # separate groups by type
-        _groups = {}
-        for key, val in _items:
-            _type = val.get("type", "null")
-            if _type not in _groups.keys():
-                _groups[_type] = []
-            _groups[_type].append(val)
-        return _groups
-
-    @staticmethod
-    def _collect_category_display_names(category_definition_data, mode=None):
-        """Collect category display names and return a dictionary.
-        This essentially uses the display name as the key and category_definition key
-        as the value.
-        """
-        _display_name_dict = {}
-        for key, data in category_definition_data.items():
-            if data.get("type", None) == mode:
-                _display_name_dict[data["display_name"]] = key
-        return _display_name_dict
-
-    @staticmethod
-    def filter_category_definitions(category_definition_data, mode=None):
-        """Filter category definitions."""
-        filtered_data = {}
-        for key, data in category_definition_data.items():
-            _type = data.get("type", None)
-            _archived = data.get("archived", False)
-            if _archived:
-                continue
-            if _type and _type != mode:
-                continue
-            filtered_data[key] = data
-        return filtered_data
-
-    def define_ui_dictionary(self):
-        """Populate settings."""
-
-        _mode = self._parent_sub.metadata.get_value("mode", "")
-        all_categories = self._parent_sub.guard.category_definitions.get_data()
-        _default_categories = self.filter_category_definitions(
-            all_categories, mode=_mode
-        )
-
-        _ui_definition = {
-            "name": {
-                "display_name": "Name :",
-                "type": "validatedString",
-                "value": self.task_object.name,
-                "tooltip": "Name of the new task.",
-                "readOnly": True,
-            },
-            "path": {
-                "display_name": "Path :",
-                "type": "string",
-                "value": self._parent_sub.path,
-                "tooltip": "Path of the new task.",
-                "readOnly": True,
-            },
-            "categories": {
-                "display_name": "Categories :",
-                "type": "categoryList",
-                "value": list(self.task_object.categories.keys()),
-                "category_list": _default_categories,
-                "tooltip": "Categories of the new task.",
-            },
-        }
-
-        return _ui_definition
-
-    def _init_ui(self):
-        """Initialize UI."""
-        self.main_layout = QtWidgets.QVBoxLayout(self)
-        self.settings_data = Settings()
-        self.settings_layout = tik_manager4.ui.layouts.settings_layout.SettingsLayout(
-            self.ui_definition, self.settings_data, parent=self
-        )
-        self.main_layout.addLayout(self.settings_layout)
-        # create a button box
-        self.button_box = TikButtonBox(
-            QtWidgets.QDialogButtonBox.Ok | QtWidgets.QDialogButtonBox.Cancel
-        )
-        # get the name ValidatedString widget and connect it to the ok button
-        _name_line_edit = self.settings_layout.find("name")
-        _name_line_edit.add_connected_widget(
-            self.button_box.button(QtWidgets.QDialogButtonBox.Ok)
-        )
-        self.main_layout.addWidget(self.button_box)
-
-        # SIGNALS
-        self.button_box.accepted.connect(self.on_edit_task)
-        self.button_box.rejected.connect(self.reject)
-
-    def on_edit_task(self):
-        """Create task."""
-        _name = self.settings_data.get_property("name")
-        self.task_object.edit(
-            name=_name, categories=self.settings_data.get_property("categories")
-        )
-        self.accept()
-
-
-class NewTask(QtWidgets.QDialog):
-    def __init__(self, project_object, parent_sub=None, parent=None, *args, **kwargs):
-        """
-        Dialog for new task creation.
-
-        """
-        super(NewTask, self).__init__(parent=parent, *args, **kwargs)
-        self.tik_project = project_object
-        self.feedback = feedback.Feedback(parent=self)
+    def __init__(
+        self,
+        parent_sub,
+        parent=None,
+    ):
+        super(TaskDialog, self).__init__(parent=parent)
 
         if parent_sub and not isinstance(parent_sub, list):
             parent_sub = [parent_sub]
+        self._parent_sub = parent_sub
+        self.metadata_definitions = self._parent_sub[0].guard.metadata_definitions
+        self.inherited_metadata = self._parent_sub[0].metadata
 
-        self._parent_sub = parent_sub or project_object
-        # self._multi_parent_subs = multi_subs
-        self.parent = parent
-        self.setWindowTitle("New Task")
-        self.setFixedSize(600, 400)
+        self.feedback = feedback.Feedback(parent=self)
+
+        self.setMinimumSize(600, 400)
         self.setModal(True)
 
         self.category_type_dictionary = self._categorize_category_definitions()
 
-        self.ui_definition = self.define_ui_dictionary()
-        self._init_ui()
+        self.primary_data = Settings()
+        self.secondary_data = Settings()
+        self.tertiary_data = Settings()
 
-        self._new_tasks = []
+        self.main_layout = QtWidgets.QVBoxLayout(self)
 
     def _categorize_category_definitions(self):
         """Categorize category definitions."""
@@ -202,7 +84,7 @@ class NewTask(QtWidgets.QDialog):
             filtered_data[key] = data
         return filtered_data
 
-    def define_ui_dictionary(self):
+    def define_primary_ui(self):
         """Populate settings."""
 
         # get the metadata from the last selected one
@@ -236,14 +118,127 @@ class NewTask(QtWidgets.QDialog):
 
         return _ui_definition
 
+    def get_metadata_value(self, key):
+        """Convenient method to get the metadata value."""
+        return self._parent_sub[0].metadata.get_value(key, None)
+
+    def _get_metadata_override(self, key):
+        """Convenience method to get the metadata override."""
+        return self._parent_sub[0].metadata.is_overridden(key)
+
+    def _get_metadata_type(self, data):
+        """Get the correct SettingsLayout type for the metadata value."""
+        default_value = data.get("default", None)
+        enums = data.get("enum", [])
+        data_type = tik_manager4.ui.layouts.settings_layout.guess_data_type(
+            default_value, enums
+        )
+        if not data_type:
+            raise ValueError(
+                "Unsupported metadata type: {}".format(type(default_value))
+            )
+        return data_type, default_value, enums
+
+    def define_other_ui(self):
+        """Define the secondary UI."""
+        _secondary_ui = {}
+        _tertiary_ui = {}
+        # The next part of metadata is for displaying and overriding
+        # the existing metadata keys in the stream
+        for key, data in self.metadata_definitions.properties.items():
+            _value_type, _default_value, _enum = self._get_metadata_type(data)
+            # _default_value = self.get_metadata_value(key) or data.get("default", None)
+            _default_value = self.get_metadata_value(key) or _default_value
+            if _default_value is None:
+                raise ValueError("No default value defined for metadata {}".format(key))
+
+            if key in self.inherited_metadata.keys():
+                # if the metadata already defined, create it with override option
+                _secondary_ui["{}_override".format(key)] = {
+                    "display_name": "{} (Override):".format(key),
+                    "type": "multi",
+                    "tooltip": "Override {}".format(key),
+                    "value": {
+                        "__override_{}".format(key): {
+                            "type": "boolean",
+                            "value": self._get_metadata_override(key),
+                            "disables": [[False, key]],
+                        },
+                        key: {
+                            "type": _value_type,
+                            "value": _default_value,
+                            "items": _enum,
+                        },
+                    },
+                }
+            else:
+                # if the metadata is not defined, create it with new option
+                _tertiary_ui[key] = {
+                    "display_name": "{} :".format(key),
+                    "type": "multi",
+                    "tooltip": "New {}".format(key),
+                    "value": {
+                        "__new_{}".format(key): {
+                            "type": "boolean",
+                            "value": False,
+                            "disables": [[False, key]],
+                        },
+                        key: {
+                            "type": _value_type,
+                            "value": _default_value,
+                            "items": _enum,
+                        },
+                    },
+                }
+
+        return _secondary_ui, _tertiary_ui
+
     def _init_ui(self):
         """Initialize UI."""
-        self.main_layout = QtWidgets.QVBoxLayout(self)
-        self.settings_data = Settings()
+        primary_definition = self.define_primary_ui()
+        secondary_definition, tertiary_definition = self.define_other_ui()
+
         self.settings_layout = tik_manager4.ui.layouts.settings_layout.SettingsLayout(
-            self.ui_definition, self.settings_data, parent=self
+            primary_definition, self.primary_data, parent=self
         )
         self.main_layout.addLayout(self.settings_layout)
+
+        # create a metadata layout which has a scroll area
+        metadata_layout = QtWidgets.QVBoxLayout()
+        self.main_layout.addLayout(metadata_layout)
+
+        scroll_area = QtWidgets.QScrollArea(self)
+        scroll_area.setWidgetResizable(True)
+        scroll_area.setFrameShape(QtWidgets.QFrame.NoFrame)
+        scroll_area.setFrameShadow(QtWidgets.QFrame.Plain)
+        scroll_area.setLineWidth(0)
+        scroll_area.setMidLineWidth(0)
+        scroll_area.setContentsMargins(0, 0, 0, 0)
+
+        # creata a widget for contents
+        contents_widget = QtWidgets.QWidget()
+        contents_widget.setContentsMargins(0, 0, 0, 0)
+
+        scroll_area.setWidget(contents_widget)
+
+        metadata_layout.addWidget(scroll_area)
+        scroll_layout = QtWidgets.QVBoxLayout(contents_widget)
+        scroll_layout.setContentsMargins(0, 0, 0, 0)
+
+        self.secondary_layout = CollapsibleLayout("Inherited Properties", expanded=True)
+        scroll_layout.addLayout(self.secondary_layout)
+        self.tertiary_layout = CollapsibleLayout("New Properties", expanded=False)
+        scroll_layout.addLayout(self.tertiary_layout)
+
+        secondary_content = tik_manager4.ui.layouts.settings_layout.SettingsLayout(
+            secondary_definition, self.secondary_data, parent=self
+        )
+        self.secondary_layout.contents_layout.addLayout(secondary_content)
+        tertiary_content = tik_manager4.ui.layouts.settings_layout.SettingsLayout(
+            tertiary_definition, self.tertiary_data, parent=self
+        )
+        self.tertiary_layout.contents_layout.addLayout(tertiary_content)
+
         # create a button box
         self.button_box = TikButtonBox(
             QtWidgets.QDialogButtonBox.Ok | QtWidgets.QDialogButtonBox.Cancel
@@ -262,16 +257,36 @@ class NewTask(QtWidgets.QDialog):
             self.setWindowTitle("New Task (Multiple Selection)")
 
         # SIGNALS
-        self.button_box.accepted.connect(self.on_create_task)
+        self.button_box.accepted.connect(self.execute)
         self.button_box.rejected.connect(self.reject)
 
-    def on_create_task(self):
-        """Create task."""
+    def execute(self):
+        pass
+
+
+class NewTask(TaskDialog):
+    def __init__(self, project_object, parent_sub=None, parent=None, *args, **kwargs):
+        super(NewTask, self).__init__(parent_sub, parent=parent, *args, **kwargs)
+        self.setWindowTitle("New Task")
+        self.tik_project = project_object
+
+        self._new_tasks = []
+
+        self._init_ui()
+
+    def execute(self):
+        """Create Task(s)."""
+
+        filtered_data = FilteredData()
+        filtered_data.update_overridden_data(self.secondary_data)
+        filtered_data.update_new_data(self.tertiary_data)
+
         for sub in self._parent_sub:
             _new_task = self.tik_project.create_task(
-                name=self.settings_data.get_property("name"),
-                categories=self.settings_data.get_property("categories"),
+                name=self.primary_data.get_property("name"),
+                categories=self.primary_data.get_property("categories"),
                 parent_uid=sub.id,
+                metadata_overrides=filtered_data,
             )
             if _new_task == -1:
                 self.feedback.pop_info(
@@ -285,3 +300,78 @@ class NewTask(QtWidgets.QDialog):
 
     def get_created_task(self):
         return self._new_tasks
+
+    def _get_metadata_override(self, key):
+        """Override the function to return always False."""
+        return False
+
+
+class EditTask(TaskDialog):
+    """Dialog for task editing."""
+
+    def __init__(self, task_object, parent_sub=None, parent=None, *args, **kwargs):
+        self.task_object = task_object
+        super(EditTask, self).__init__(
+            parent_sub=parent_sub, parent=parent, *args, **kwargs
+        )
+        self.setWindowTitle("Edit Task")
+        self.inherited_metadata = self.task_object.metadata
+
+        self._init_ui()
+
+    def define_primary_ui(self):
+        """Populate settings."""
+
+        _mode = self.task_object.metadata.get_value("mode", "")
+        all_categories = self.task_object.guard.category_definitions.get_data()
+        _default_categories = self.filter_category_definitions(
+            all_categories, mode=_mode
+        )
+
+        _ui_definition = {
+            "name": {
+                "display_name": "Name :",
+                "type": "validatedString",
+                "value": self.task_object.name,
+                "tooltip": "Name of the new task.",
+                "readOnly": True,
+            },
+            "path": {
+                "display_name": "Path :",
+                "type": "string",
+                "value": self._parent_sub[0].path,
+                "tooltip": "Path of the new task.",
+                "readOnly": True,
+            },
+            "categories": {
+                "display_name": "Categories :",
+                "type": "categoryList",
+                "value": list(self.task_object.categories.keys()),
+                "category_list": _default_categories,
+                "tooltip": "Categories of the new task.",
+            },
+        }
+
+        return _ui_definition
+
+    def get_metadata_value(self, key):
+        """Convenient method to get the metadata value."""
+        return self.task_object.metadata.get_value(key, None)
+
+    def _get_metadata_override(self, key):
+        """Convenience method to get the metadata override."""
+        return self.task_object.metadata.is_overridden(key)
+
+    def execute(self):
+        """Edit task."""
+        filtered_data = FilteredData()
+        filtered_data.update_overridden_data(self.secondary_data)
+        filtered_data.update_new_data(self.tertiary_data)
+
+        _name = self.primary_data.get_property("name")
+        self.task_object.edit(
+            name=_name,
+            categories=self.primary_data.get_property("categories"),
+            metadata_overrides=filtered_data,
+        )
+        self.accept()

--- a/tik_manager4/ui/layouts/collapsible_layout.py
+++ b/tik_manager4/ui/layouts/collapsible_layout.py
@@ -46,8 +46,8 @@ QPushButton
 }
 """
 
-    def __init__(self, text="", expanded=False, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(self, text="", expanded=False, parent=None):
+        super().__init__(parent)
 
         self.setContentsMargins(0, 0, 0, 0)
         self.setSpacing(0)

--- a/tik_manager4/ui/main.py
+++ b/tik_manager4/ui/main.py
@@ -566,11 +566,11 @@ class MainUI(QtWidgets.QMainWindow):
         self.categories_mcv.work_tree_view.ingest_here(selected_work_item)
 
     #
-    def _new_work_pre_checks(self, subproject):
+    def _new_work_pre_checks(self, task):
         """Collection of pre-checks for the new work method."""
         dcc_name = self.tik.project.guard.dcc
         current_dcc_version = self.tik.dcc.get_dcc_version()
-        metadata_dcc_version = subproject.metadata.get_value(f"{dcc_name.lower()}_version", None)
+        metadata_dcc_version = task.metadata.get_value(f"{dcc_name.lower()}_version", None)
         if metadata_dcc_version:
             if current_dcc_version != metadata_dcc_version:
                 msg = f"The current dcc version ({current_dcc_version}) \
@@ -578,7 +578,7 @@ class MainUI(QtWidgets.QMainWindow):
                 yield msg
 
         for msg in self.categories_mcv.work_tree_view.metadata_pre_checks(
-                self.tik.dcc, subproject.metadata):
+                self.tik.dcc, task.metadata):
             yield msg
 
     def on_work_from_template(self):
@@ -708,7 +708,7 @@ class MainUI(QtWidgets.QMainWindow):
             self.feedback.pop_info(title="DCC Error", text=dcc_issues, critical=True)
             return
 
-        pre_checks = self._new_work_pre_checks(subproject)
+        pre_checks = self._new_work_pre_checks(task)
         for check_msg in pre_checks:
             question = self.feedback.pop_question(
                 title="Metadata Mismatch",
@@ -738,7 +738,7 @@ class MainUI(QtWidgets.QMainWindow):
                    f"Defined DCC version: {dcc_version_mismatch[0]}\n\n")
             yield msg
 
-        for msg in self.categories_mcv.work_tree_view.metadata_pre_checks(self.tik.dcc, metadata):
+        for msg in self.categories_mcv.work_tree_view.metadata_pre_checks(self.tik.dcc, work_obj.get_metadata()):
             yield msg
 
     def on_new_version(self):

--- a/tik_manager4/ui/mcv/category_mcv.py
+++ b/tik_manager4/ui/mcv/category_mcv.py
@@ -622,14 +622,13 @@ class TikCategoryView(QtWidgets.QTreeView):
 
         # get the metadata for the checks.
         parent_task = item.tik_obj.parent_task
-        metadata = parent_task.parent_sub.metadata
 
         # check the dcc for any issues that may prevent saving.
         dcc_issues = item.tik_obj.guard.dcc_handler.pre_save_issues()
         if dcc_issues:
             self.feedback.pop_info(title="DCC Error", text=dcc_issues, critical=True)
             return
-        pre_checks = self.new_version_pre_checks(item.tik_obj, metadata)
+        pre_checks = self.new_version_pre_checks(item.tik_obj, parent_task.metadata)
 
         if not item.dcc_check():
             self.feedback.pop_info(


### PR DESCRIPTION
With this commit, the metadata can be accessed and altered within tasks. Each task inherits the metadata the same way the sub-projects does and has the ability to override it.
The changes reflected to the UI when creating and editing the tasks.

The query of metadata and passing it to the extractors, validators and ingestors are simplified without the requirement of resolving of the subproject.

As a future feature, this will allow to move the tasks between subproject with a possibility to 'freeze' any metadata they are inheriting.