### PR TITLE
TIK-163 simple way to create a project structure template

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -621,3 +621,18 @@ def test_import_from_path(tmp_path):
     module_file.write_text("value = 42")
     module = utils.import_from_path("test_module", str(module_file))
     assert module.value == 42
+
+def test_copy_data():
+    """Test the copy_data function."""
+    settings = Settings()
+    original_data = {"key1": "value1", "key2": {"subkey": "subvalue"}}
+    settings.initialize(original_data)
+
+    copied_data = settings.copy_data()
+
+    # Ensure the copied data is the same as the original
+    assert copied_data == original_data
+
+    # Ensure the copied data is a deep copy (modifying it should not affect the original)
+    copied_data["key2"]["subkey"] = "new_subvalue"
+    assert settings.get_property("key2")["subkey"] == "subvalue"

--- a/tik_manager4/core/settings.py
+++ b/tik_manager4/core/settings.py
@@ -210,6 +210,10 @@ class Settings:
         """Return the whole current data."""
         return self._current_value
 
+    def copy_data(self):
+        """Return a copy of the current data."""
+        return deepcopy(self._current_value)
+
     def set_fallback(self, file_path):
         """Use the given file in case the file_path is not found.
 

--- a/tik_manager4/core/utils.py
+++ b/tik_manager4/core/utils.py
@@ -228,3 +228,13 @@ def import_from_path(module_name, file_path, cleanup=True):
             sys.path.remove(parent_dir)
 
     return module
+
+def remove_key(data, key):
+    """Recursively traverse the data and remove the key."""
+    if isinstance(data, dict):
+        return {k: remove_key(v, key) for k, v in data.items() if
+                k != key}
+    elif isinstance(data, list):
+        return [remove_key(item, key) for item in data]
+    else:
+        return data

--- a/tik_manager4/objects/main.py
+++ b/tik_manager4/objects/main.py
@@ -202,6 +202,26 @@ class Main:
         self.globalize_management_platform()
         return 1
 
+    def add_project_as_structure_template(self, template_name=None):
+        """Add the current project as a new structure template."""
+        # check for the permission level
+        if self.user.permission_level < 3:
+            self.log.warning("This user does not have rights to perform this action")
+            return False
+
+        current_structure = self.project.structure.copy_data()
+        # go through the structure and remove the ids
+        filtered_structure = utils.remove_key(current_structure, "id")
+        filtered_structure["name"] = template_name
+        print(filtered_structure)
+
+        self.user.commons.structures.add_property(template_name, filtered_structure)
+        self.user.commons.structures.apply_settings()
+
+        return True
+
+
+
     def collect_template_paths(self):
         """Collect all template files from common, project and user folders.
 

--- a/tik_manager4/ui/dialog/project_dialog.py
+++ b/tik_manager4/ui/dialog/project_dialog.py
@@ -1,9 +1,6 @@
 """Dialog for setting project."""
 
 import os
-from logging import critical
-
-from coverage.debug import info_header
 
 from tik_manager4.ui.Qt import QtWidgets, QtCore, QtGui
 from tik_manager4.ui.widgets import path_browser

--- a/tik_manager4/ui/main.py
+++ b/tik_manager4/ui/main.py
@@ -32,7 +32,7 @@ from tik_manager4.management.exceptions import SyncError
 from tik_manager4.ui import pick
 from tik_manager4.ui.Qt import QtWidgets, QtCore, QtGui
 from tik_manager4.ui.dialog.feedback import Feedback, Confirmation
-from tik_manager4.ui.dialog.project_dialog import NewProjectDialog
+from tik_manager4.ui.dialog.project_dialog import NewProjectDialog, SetProjectAsTemplateDialog
 from tik_manager4.ui.dialog.publish_dialog import PublishSceneDialog
 from tik_manager4.ui.dialog.settings_dialog import SettingsDialog
 from tik_manager4.ui.dialog import support_splash
@@ -413,21 +413,10 @@ class MainUI(QtWidgets.QMainWindow):
         )
         self.categories_mcv.work_tree_view.file_dropped.connect(self.on_save_any_file)
         self.categories_mcv.work_tree_view.work_resurrected.connect(self.refresh_project)
-        # self.categories_mcv.work_tree_view.work_resurrected.connect(
-        #     self.subprojects_mcv.sub_view.refresh
-        # )
+
         self.versions_mcv.version.preview_btn.clicked.connect(self.on_show_preview)
         self.versions_mcv.element_view_event.connect(self.on_element_view)
         self.versions_mcv.version_resurrected.connect(self.refresh_project)
-        # self.versions_mcv.version_resurrected.connect(
-        #     self.categories_mcv.work_tree_view.refresh
-        # )
-        # self.versions_mcv.version_resurrected.connect(
-        #     self.tasks_mcv.task_view.refresh
-        # )
-        # self.versions_mcv.version_resurrected.connect(
-        #     self.subprojects_mcv.sub_view.refresh
-        # )
 
         if self.tik.dcc.name == "Standalone":
             self.categories_mcv.work_tree_view.save_new_work_event.connect(
@@ -567,6 +556,10 @@ class MainUI(QtWidgets.QMainWindow):
         )
         file_menu.addAction(settings_item)
         file_menu.addSeparator()
+        set_as_template = QtWidgets.QAction("&Set as Template", self)
+        file_menu.addAction(set_as_template)
+        file_menu.addSeparator()
+
         user_login = QtWidgets.QAction(pick.icon("user"), "&User Login", self)
         file_menu.addAction(user_login)
         exit_action = QtWidgets.QAction("&Exit", self)
@@ -618,6 +611,7 @@ class MainUI(QtWidgets.QMainWindow):
         user_login.triggered.connect(self.on_login)
         settings_item.triggered.connect(self.on_settings)
         set_project.triggered.connect(self.project_mcv.set_project)
+        set_as_template.triggered.connect(self.on_set_project_as_template)
         exit_action.triggered.connect(self.close)
 
         save_new_work.triggered.connect(self.on_new_work)
@@ -1212,6 +1206,14 @@ class MainUI(QtWidgets.QMainWindow):
         """
         executable = self.tik.user.settings.get(f"{element_type}_viewer", None)
         utils.execute(element_path, executable=executable)
+
+    def on_set_project_as_template(self):
+        """Set the current project as a template."""
+        # pre-check the permissions
+        if not self._pre_check(level=3):
+            return
+        dialog = SetProjectAsTemplateDialog(self.tik, parent=self)
+        dialog.show()
 
     def _pre_check(self, level):
         """Check for permissions before drawing the dialog."""


### PR DESCRIPTION
 a simple way to be able to create project structure templates that will be added to the template list when creating new projects.
 
 A new Mini-ui can be launched from file -> Set as Template. This takes the ‘current project’ converts it to a template and adds it to the commons - structures.json.