### PR TITLE
TIK-167 Prevent the ability to set any project

### DIFF
--- a/tik_manager4/core/constants.py
+++ b/tik_manager4/core/constants.py
@@ -1,5 +1,6 @@
 """Constants used in the Tik Manager application."""
 
+from dataclasses import dataclass
 from enum import Enum
 
 class ObjectType(Enum):
@@ -14,3 +15,16 @@ class ObjectType(Enum):
     SUBPROJECT = "subproject"
     PROJECT = "project"
     USER = "user"
+
+class ValidationState(Enum):
+    """Enumeration of validation states."""
+    SUCCESS = "success"
+    WARNING = "warning"
+    ERROR = "error"
+
+@dataclass
+class ValidationResult:
+    """Dataclass to store validation results."""
+    state: ValidationState
+    message: str
+    allow_proceed: bool = False # Allow the user to proceed with the action

--- a/tik_manager4/objects/project.py
+++ b/tik_manager4/objects/project.py
@@ -100,6 +100,8 @@ class Project(Subproject):
         self.settings.settings_file = str(_database_path_obj / "project_settings.json")
         project_commons_id = self.settings.get_property("commons_id", None)
         project_commons_name = self.settings.get_property("commons_name", "")
+        print(f"Project Commons ID: {project_commons_id}")
+        print(f"Project Commons Name: {project_commons_name}")
         if project_commons_id and project_commons_id != commons_id:
             return False, f"Commons ID Mismatch\n\nThis project is linked to a different commons:\nID: {project_commons_id}\nName: {project_commons_name}\n\nTo access this project, you need to switch to the corresponding commons."
         self.guard.set_project_settings(self.settings)

--- a/tik_manager4/ui/dialog/project_dialog.py
+++ b/tik_manager4/ui/dialog/project_dialog.py
@@ -2,6 +2,7 @@
 
 import os
 
+from tik_manager4.core.constants import ValidationState
 from tik_manager4.ui.Qt import QtWidgets, QtCore, QtGui
 from tik_manager4.ui.widgets import path_browser
 from tik_manager4.ui.widgets.common import TikButton, TikButtonBox
@@ -163,12 +164,24 @@ class SetProjectDialog(QtWidgets.QDialog):
                 the folders or bookmarks and press 'Set'",
             )
             return
+        validation = self.main_object.can_set_project(project_to_set)
+        if validation.state != ValidationState.SUCCESS:
+            if not validation.allow_proceed:
+                self.feedback.pop_error(
+                    title="Cannot set project",
+                    text=validation.message,
+                )
+                return
+            ret = self.feedback.pop_question(title="Warning",
+                                                 text=validation.message,
+                                                 buttons=["yes", "no"])
+            if ret == "no":
+                return
         state, msg = self.main_object.set_project(project_to_set)
         if not state:
             self.feedback.pop_error(title="Cannot set project", text=msg)
             return
         self.accept()
-        # self.close()
 
     def on_add_bookmark(self):
         """Called when the add bookmark button is clicked."""


### PR DESCRIPTION
TIK-167 Preventing the immediate ability to set any arbitrary folder as the project. User will be warned or the action will be prevented according to the permissions.