### PR TITLE
HOTFIX - fbx export bug

### DIFF
--- a/tik_manager4/dcc/maya/extract/fbx.py
+++ b/tik_manager4/dcc/maya/extract/fbx.py
@@ -44,6 +44,12 @@ class Fbx(ExtractCore):
                     "type": "boolean",
                     "value": False,
                 },
+                "animation_only": {
+                    "display_name": "Animation Only",
+                    "type": "boolean",
+                    "value": False,
+                    "tooltip": "Export only the animation data",
+                }
             },
             "Layout": {
                 "start_frame": {
@@ -56,6 +62,12 @@ class Fbx(ExtractCore):
                     "type": "integer",
                     "value": _ranges[3],
                 },
+                "animation_only": {
+                    "display_name": "Animation Only",
+                    "type": "boolean",
+                    "value": False,
+                    "tooltip": "Export only the animation data",
+                }
             },
             "Fx": {
                 "start_frame": {
@@ -138,7 +150,7 @@ class Fbx(ExtractCore):
             _file_path,
             selection_only=False,
             animation=True,
-            animation_only=True,
+            animation_only=settings.get("animation_only"),
             bake_animation=settings.get("bake_animation"),
             bake_start=settings.get("start_frame"),
             bake_end=settings.get("end_frame"),
@@ -155,7 +167,7 @@ class Fbx(ExtractCore):
             _file_path,
             selection_only=False,
             animation=True,
-            animation_only=True,
+            animation_only=settings.get("animation_only"),
             bake_animation=settings.get("bake_animation"),
             bake_start=settings.get("start_frame"),
             bake_end=settings.get("end_frame"),

--- a/tik_manager4/dcc/maya/fbx_utility.py
+++ b/tik_manager4/dcc/maya/fbx_utility.py
@@ -119,12 +119,20 @@ def _format(value):
     return value
 
 
-def _set_fbx_settings(**kwargs):
+def _set_fbx_import_settings(**kwargs):
     """Build FBX import settings"""
     for key, value in kwargs.items():
         value = _format(value)
         if key in import_settings.keys():
             cmd = import_settings[key].format(value)
+            mel.eval(cmd)
+
+def _set_fbx_export_settings(**kwargs):
+    """Build FBX export settings"""
+    for key, value in kwargs.items():
+        value = _format(value)
+        if key in export_settings.keys():
+            cmd = export_settings[key].format(value)
             mel.eval(cmd)
 
 
@@ -279,7 +287,7 @@ def load(
             cmds.namespace(addNamespace=namespace)
         cmds.namespace(setNamespace=namespace)
 
-    _set_fbx_settings(**locals())
+    _set_fbx_import_settings(**locals())
 
     # file_path = file_path.replace("\\", "//")  ## for compatibility with mel syntax.
     # import_cmd = ('FBXImport -f "{0}" -t {1};'.format(file_path, take))
@@ -459,7 +467,7 @@ def save(
     settings_dict.pop("selection_only")
     settings_dict.pop("force")
 
-    _set_fbx_settings(**settings_dict)
+    _set_fbx_export_settings(**settings_dict)
 
     _export_fbx(file_path, selected=selection_only)
     return file_path


### PR DESCRIPTION
fbx export bug which prevents baking animations in Maya fixed. The 'animation_only' option exposed to the UI which allows extracting only anim data