### PR TITLE
Fix sub-project highights on selection

### DIFF
--- a/tik_manager4/ui/mcv/subproject_mcv.py
+++ b/tik_manager4/ui/mcv/subproject_mcv.py
@@ -191,6 +191,7 @@ class TikSubView(QtWidgets.QTreeView):
         self._feedback = Feedback(parent=self)
         self.setUniformRowHeights(True)
         self.setSelectionBehavior(QtWidgets.QAbstractItemView.SelectRows)
+        self.setObjectName("subview")
 
         self.model = None
         self.proxy_model = None

--- a/tik_manager4/ui/theme/tikManager.qss
+++ b/tik_manager4/ui/theme/tikManager.qss
@@ -1352,6 +1352,11 @@ QColumnView::item:selected:active {
   border-radius: 0px;
 }
 
+QTreeView#subview::item:selected:active,
+QTreeView#subview::item:selected:!active {
+  background-color: #242424;
+}
+
 QTreeView::item:!selected:hover,
 QListView::item:!selected:hover,
 QTableView::item:!selected:hover,


### PR DESCRIPTION
This is considered as minor since it's only happening for specific OS and some DCCs that handle the stylesheet differently.
But this fix is now safe because this is not interfering with another dialog anymore.