### PR TITLE
Fix error on task creation when a sub-project is not selected

### DIFF
--- a/tik_manager4/ui/mcv/subproject_mcv.py
+++ b/tik_manager4/ui/mcv/subproject_mcv.py
@@ -662,6 +662,16 @@ class TikSubView(QtWidgets.QTreeView):
             message, title = self.model.project.log.get_last_message()
             self._feedback.pop_info(title.capitalize(), message)
             return
+
+        # check for sub-projects selection
+        if not sub_projects:
+            self._feedback.pop_info(
+                "No sub-project selected",
+                "Please selected a Sub-project before creating a task.",
+                critical=True
+            )
+            return
+
         _dialog = tik_manager4.ui.dialog.task_dialog.NewTask(
             self.model.project, parent_sub=sub_projects, parent=self
         )


### PR DESCRIPTION
On task creation, when the selection is empty on sub-project, there is an error in PyQt, but silent error in PySide.
Also, it might be useful to warn the user with a critical dialog.

<img width="715" height="617" alt="image" src="https://github.com/user-attachments/assets/0f336ecf-f98a-4431-8e0e-23edac244d34" />
